### PR TITLE
Initialize TBBUTTON and always assign bitmap index for toolbar buttons

### DIFF
--- a/wb/wb_control_toolbar.c
+++ b/wb/wb_control_toolbar.c
@@ -108,18 +108,16 @@ static HWND CreateToolbar(HWND hwndParent, int nButtons, int nBtnWidth, int nBtn
 
 static BOOL CreateToolbarButton(HWND hwnd, int id, int nIndex, LPCTSTR pszHint)
 {
-	TBBUTTON tbb;
+	TBBUTTON tbb = {0};
 	BOOL bRet;
 
 	tbb.fsState = TBSTATE_ENABLED;
-	tbb.dwData = 0;
 
 	if (id == 0)
 	{ // Separator
 		tbb.idCommand = 0;
 		tbb.fsState = 0;
 		tbb.fsStyle = TBSTYLE_SEP;
-		tbb.dwData = 0;
 		tbb.iBitmap = 0;
 		tbb.iString = 0;
 	}
@@ -128,6 +126,8 @@ static BOOL CreateToolbarButton(HWND hwnd, int id, int nIndex, LPCTSTR pszHint)
 		tbb.idCommand = id;
 		tbb.fsState = TBSTATE_ENABLED;
 		tbb.fsStyle = TBSTYLE_BUTTON;
+		tbb.iBitmap = nIndex;
+		tbb.iString = 0;
 		if (pszHint && *pszHint)
 		{
 		    // Convert UTF-8 to wide char using Windows API
@@ -145,8 +145,6 @@ static BOOL CreateToolbarButton(HWND hwnd, int id, int nIndex, LPCTSTR pszHint)
 		}
 		else {
 			tbb.dwData = 0;
-		    tbb.iBitmap = nIndex;
-		    tbb.iString = nIndex;
 		}
 	}
 


### PR DESCRIPTION
### Motivation
- Prevent `TBBUTTON` fields from being left uninitialized which could cause incorrect toolbar icon rendering on first run. 
- Ensure toolbar buttons always receive the intended image index and avoid leaving `iString` uninitialized when tooltip text is stored in `dwData`.

### Description
- Zero-initialize the `TBBUTTON` struct by changing the declaration to `TBBUTTON tbb = {0};`.
- Always assign `tbb.iBitmap = nIndex` for real toolbar buttons (`id != 0`) and set `tbb.iString = 0` for buttons while continuing to store tooltip payload in `tbb.dwData` when provided.
- Preserve separator behavior (`TBSTYLE_SEP`) while relying on the initialized struct state instead of ad-hoc assignments.

### Testing
- Inspected the applied patch with `git diff -- wb/wb_control_toolbar.c` and confirmed the intended edits were present. 
- Committed the change with `git commit` and validated repository status using `git status --short`.
- GUI runtime verification (creating a toolbar with multiple distinct image indices and hints to confirm every button draws its own icon on first run) could not be executed in this Linux container and should be validated on Windows during integration testing.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909ac989d4832cb5d1b901112c94d2)