### PR TITLE
Pass parent callback object in ImageButtonProc handlers

### DIFF
--- a/wb/wb_control.c
+++ b/wb/wb_control.c
@@ -2456,7 +2456,7 @@ static LRESULT CALLBACK ImageButtonProc(HWND hwnd, UINT64 msg, WPARAM wParam, LP
 
 				if (pwbo && pwbo->parent && pwbo->parent->pszCallBackFn && *pwbo->parent->pszCallBackFn)
 				{
-					wbCallUserFunction(pwbo->parent->pszCallBackFn, pwbo->pszCallBackObj, pwbo->parent, pwbo, pwbo->id,
+					wbCallUserFunction(pwbo->parent->pszCallBackFn, pwbo->parent->pszCallBackObj, pwbo->parent, pwbo, pwbo->id,
 									   WBC_MOUSEMOVE | wParam | dwAlt, lParam, 0);
 				}
 			}
@@ -2478,7 +2478,7 @@ static LRESULT CALLBACK ImageButtonProc(HWND hwnd, UINT64 msg, WPARAM wParam, LP
 			// Sets the timer for the first delay
 			if (pwbo && pwbo->parent && pwbo->parent->pszCallBackFn && *pwbo->parent->pszCallBackFn)
 			{
-				wbCallUserFunction(pwbo->parent->pszCallBackFn, pwbo->pszCallBackObj, pwbo->parent, pwbo, pwbo->id, wParam, lParam, 0);
+				wbCallUserFunction(pwbo->parent->pszCallBackFn, pwbo->parent->pszCallBackObj, pwbo->parent, pwbo, pwbo->id, wParam, lParam, 0);
 			}
 
 			M_bRepeatOn = FALSE;
@@ -2504,7 +2504,7 @@ static LRESULT CALLBACK ImageButtonProc(HWND hwnd, UINT64 msg, WPARAM wParam, LP
 		{
 			if (pwbo && pwbo->parent && pwbo->parent->pszCallBackFn && *pwbo->parent->pszCallBackFn)
 			{
-				wbCallUserFunction(pwbo->parent->pszCallBackFn, pwbo->pszCallBackObj, pwbo->parent, pwbo, pwbo->id,
+				wbCallUserFunction(pwbo->parent->pszCallBackFn, pwbo->parent->pszCallBackObj, pwbo->parent, pwbo, pwbo->id,
 								   wParam, lParam, 0);
 			}
 		}
@@ -2580,7 +2580,7 @@ static LRESULT CALLBACK ImageButtonProc(HWND hwnd, UINT64 msg, WPARAM wParam, LP
 			{
 				if (pwbo && pwbo->parent && pwbo->parent->pszCallBackFn && *pwbo->parent->pszCallBackFn)
 				{
-					wbCallUserFunction(pwbo->parent->pszCallBackFn, pwbo->pszCallBackObj, pwbo->parent, pwbo, pwbo->id,
+					wbCallUserFunction(pwbo->parent->pszCallBackFn, pwbo->parent->pszCallBackObj, pwbo->parent, pwbo, pwbo->id,
 									   wParam, lParam, 0);
 				}
 


### PR DESCRIPTION
### Motivation
- Ensure the parent callback function is invoked with the matching parent callback object so handlers registered on the parent (e.g. `wb_set_handler([$this, 'main_process'])`) receive the expected context during ImageButton hover/click/autorepeat flows.

### Description
- In `ImageButtonProc` message paths `WM_MOUSEMOVE`, `WM_LBUTTONDOWN`, `WM_LBUTTONUP`, and `WM_TIMER` replace `pwbo->pszCallBackObj` with `pwbo->parent->pszCallBackObj` when calling the parent callback function.
- Kept existing guard checks unchanged: `pwbo && pwbo->parent && pwbo->parent->pszCallBackFn && *pwbo->parent->pszCallBackFn` at each call site.
- The change only updates the callback object argument for four `wbCallUserFunction` invocations and introduces no other behavioral changes.

### Testing
- Located and verified call sites with `rg` to ensure all target `wbCallUserFunction` invocations were updated and no extra occurrences were left behind, and the checks were consistent.
- Inspected the modified source region with `sed`/`nl` to confirm the new `pwbo->parent->pszCallBackObj` argument is present at each of the four message handlers.
- Runtime GUI validation (interactive Windows event loop) was not executed in this environment, so automated source-level checks passed and no runtime/behavioral tests were run here.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909d0ea748832c9576dea393e84a1e)