### PR TITLE
Fix callback invocation and callable-array handling in wb_set_handler

### DIFF
--- a/phpwb_wb_lib.c
+++ b/phpwb_wb_lib.c
@@ -88,6 +88,7 @@ UINT64 wbCallUserFunction(LPCTSTR pszFunctionName, LPDWORD pszObject, PWBOBJ pwb
 	zval fname = {0};
 	zval return_value = {0};
 	zval parms[CALLBACK_ARGS];
+	zval *zobj = NULL;
 	BOOL bRet;
 	UINT64 ret = 0;
 	char *pszFName;
@@ -155,9 +156,14 @@ UINT64 wbCallUserFunction(LPCTSTR pszFunctionName, LPDWORD pszObject, PWBOBJ pwb
 	ZVAL_LONG(&parms[5], (LONG_PTR)lParam3);
 
 	// Call the user function
+	if (pszObject != NULL && Z_TYPE_P((zval *)pszObject) == IS_OBJECT)
+	{
+		zobj = (zval *)pszObject;
+	}
+
 	bRet = call_user_function(
 		NULL, // CG(function_table) Hash value for the function table
-		(zval *)&pszObject,			// Pointer to an object (may be NULL)
+		zobj,			// Pointer to an object (may be NULL)
 		&fname,				// Function name
 		&return_value,		// Return value
 		CALLBACK_ARGS,		// Parameter count

--- a/phpwb_window.c
+++ b/phpwb_window.c
@@ -425,9 +425,14 @@ ZEND_FUNCTION(wb_set_handler)
 {
 	zend_long pwbo;
 	zval *obj = NULL;
+	zval *target = NULL;
+	zval *method = NULL;
+	zend_array *target_arr = NULL;
 	zend_string *fname = NULL;
-	zval name = {0}, *zparam = NULL;
+	zval callable = {0};
+	zval *zparam = NULL;
 	char *handler = "";
+	char *scoped_handler = NULL;
 
 	TCHAR *wcsHandler = 0;
 
@@ -440,13 +445,53 @@ ZEND_FUNCTION(wb_set_handler)
 	if (!wbIsWBObj((void *)pwbo, TRUE)){
 		RETURN_BOOL(FALSE);
 	}
+
 	switch (Z_TYPE_P(zparam))
 	{
 	case IS_ARRAY:
-		parse_array(zparam, "ls", &obj, &handler);
+		target_arr = Z_ARRVAL_P(zparam);
+		if (zend_hash_num_elements(target_arr) != 2)
+		{
+			wbError(TEXT("wb_set_handler"), MB_ICONWARNING, TEXT("Callable array must contain exactly two elements: [object_or_class, method]"));
+			RETURN_BOOL(FALSE);
+		}
+
+		target = zend_hash_index_find(target_arr, 0);
+		method = zend_hash_index_find(target_arr, 1);
+		if (!target || !method)
+		{
+			wbError(TEXT("wb_set_handler"), MB_ICONWARNING, TEXT("Malformed callable array. Expected numeric indexes 0 and 1"));
+			RETURN_BOOL(FALSE);
+		}
+
+		if (Z_TYPE_P(method) != IS_STRING)
+		{
+			wbError(TEXT("wb_set_handler"), MB_ICONWARNING, TEXT("Callable array method must be a string"));
+			RETURN_BOOL(FALSE);
+		}
+
+		handler = Z_STRVAL_P(method);
+		if (Z_TYPE_P(target) == IS_OBJECT)
+		{
+			obj = emalloc(sizeof(zval));
+			ZVAL_COPY(obj, target);
+		}
+		else if (Z_TYPE_P(target) == IS_STRING)
+		{
+			spprintf(&scoped_handler, 0, "%s::%s", Z_STRVAL_P(target), handler);
+			handler = scoped_handler;
+		}
+		else
+		{
+			wbError(TEXT("wb_set_handler"), MB_ICONWARNING, TEXT("Callable array index 0 must be an object or class string"));
+			RETURN_BOOL(FALSE);
+		}
+
+		ZVAL_COPY(&callable, zparam);
 		break;
 	case IS_STRING:
 		handler = Z_STRVAL_P(zparam);
+		ZVAL_COPY(&callable, zparam);
 		break;
 	default:
 		wbError(TEXT("wb_set_handler"), MB_ICONWARNING, TEXT("Wrong data type in function"));
@@ -454,15 +499,38 @@ ZEND_FUNCTION(wb_set_handler)
 	}
 
 	// Error checking
-	if (!zend_is_callable(zparam, 0, &fname))
+	if (!zend_is_callable(&callable, 0, &fname))
 	{
-		wbError(TEXT("wb_set_handler"), MB_ICONWARNING, TEXT("%s handler is not a function or cannot be called"), fname);
+		wbError(TEXT("wb_set_handler"), MB_ICONWARNING, TEXT("%s handler is not a function or cannot be called"), fname ? ZSTR_VAL(fname) : "(unknown)");
+		if (obj)
+		{
+			zval_ptr_dtor(obj);
+			efree(obj);
+		}
+		if (scoped_handler)
+		{
+			efree(scoped_handler);
+		}
+		if (fname)
+		{
+			zend_string_release(fname);
+		}
+		zval_ptr_dtor(&callable);
 		RETURN_BOOL(FALSE);
 	}
 	else
 	{
 
 		wcsHandler = Utf82WideChar(handler, 0);
+		if (scoped_handler)
+		{
+			efree(scoped_handler);
+		}
+		if (fname)
+		{
+			zend_string_release(fname);
+		}
+		zval_ptr_dtor(&callable);
 		RETURN_BOOL(wbSetWindowHandler((PWBOBJ)pwbo, (LPDWORD)obj, wcsHandler));
 	}
 }


### PR DESCRIPTION
### Motivation
- Callbacks were not being invoked because the stored callback context was passed incorrectly to the PHP runtime, preventing `call_user_function` from receiving the expected object context. 
- Array-style callables were parsed unsafely which allowed malformed handler values to be stored and caused silent failures.

### Description
- In `phpwb_wb_lib.c` we create a `zval *zobj` when the stored callback context is an object and pass `zobj` to `call_user_function` instead of an invalid pointer, so object-contexted callbacks are dispatched correctly. 
- In `phpwb_window.c` we rework `wb_set_handler` to explicitly parse and validate array callables by requiring exactly two elements, reading numeric indexes `0` (object or class string) and `1` (method string), and handling each case appropriately. 
- For object callables we copy the object into a stored `zval` pointer, and for class callables we build a `Class::method` handler string while leaving the object context NULL so runtime dispatch works. 
- Added defensive error messages and deterministic cleanup of temporary resources (`obj`, `scoped_handler`, `fname`, and `callable`) on both success and failure paths, and preserved string-callable behavior and conversion to wide-char before calling `wbSetWindowHandler`.

### Testing
- Ran repository consistency checks (`git diff --check` and `git status --short`) which completed without errors. 
- Applied the changes to the source files and verified the updated functions are present in `phpwb_wb_lib.c` and `phpwb_window.c`. 
- No automated build or runtime unit tests were executed as part of this change set.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a03f44dc832c90b31755daf0547a)