### PR TITLE
Restore fixed-width/left-icon tab styles while fixing tab image updates

### DIFF
--- a/wb/wb_control_tab.c
+++ b/wb/wb_control_tab.c
@@ -185,22 +185,27 @@ BOOL wbCreateTabControlImageList(PWBOBJ pwbo, HBITMAP hbmImage, int nImages, COL
 
 BOOL wbSetTabControlItemImages(PWBOBJ pwbo, int item, int nImageIndex)
 {
-	TC_ITEM tabItemToUpdate;
+	TC_ITEM tabItemToUpdate = {0};
+	LONG_PTR lStyle;
 
 	if (!pwbo || !pwbo->hwnd || !IsWindow(pwbo->hwnd))
 		return FALSE;
+	if (item < 0 || item >= TabCtrl_GetItemCount(pwbo->hwnd))
+		return FALSE;
 
-	TabCtrl_GetItem(((PWBOBJ)pwbo)->hwnd, item, &tabItemToUpdate);
 	tabItemToUpdate.mask = TCIF_IMAGE;
+	tabItemToUpdate.iImage = nImageIndex; // image index
 
 	if (nImageIndex >= 0)
 	{
-		tabItemToUpdate.mask |= TCIF_IMAGE;
-		tabItemToUpdate.mask |= TCS_FIXEDWIDTH;
-		tabItemToUpdate.mask |= TCS_FORCEICONLEFT;
+		lStyle = GetWindowLongPtr(pwbo->hwnd, GWL_STYLE);
+		if ((lStyle & (TCS_FIXEDWIDTH | TCS_FORCEICONLEFT)) != (TCS_FIXEDWIDTH | TCS_FORCEICONLEFT))
+		{
+			SetWindowLongPtr(pwbo->hwnd, GWL_STYLE, lStyle | TCS_FIXEDWIDTH | TCS_FORCEICONLEFT);
+			SetWindowPos(pwbo->hwnd, NULL, 0, 0, 0, 0,
+				SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOACTIVATE | SWP_FRAMECHANGED);
+		}
 	}
-
-	tabItemToUpdate.iImage = nImageIndex; // image index
 
 	TabCtrl_SetItem(pwbo->hwnd, item, &tabItemToUpdate);
 


### PR DESCRIPTION
### Motivation
- The prior fix removed invalid `TCS_*` bits from `TC_ITEM.mask` but also lost the visual behavior that made tabs with icons fixed-width and left-aligned. 
- The change should set tab images safely while preserving the intended tab style (fixed-width + icon-left) at the control level.

### Description
- Initialize `TC_ITEM` (`TC_ITEM tabItemToUpdate = {0};`), validate the tab index with `TabCtrl_GetItemCount`, and use only `TCIF_IMAGE` when updating the item, then set `iImage` to `nImageIndex` before calling `TabCtrl_SetItem`.
- When assigning a non-negative image index, read the control style with `GetWindowLongPtr` and OR in `TCS_FIXEDWIDTH | TCS_FORCEICONLEFT` if those bits are not already both present.
- Apply the style change immediately by calling `SetWindowPos(..., SWP_FRAMECHANGED)` so the tab control updates its appearance.
- The change is contained to `wb/wb_control_tab.c` within `wbSetTabControlItemImages()`.

### Testing
- Ran `git diff -- wb/wb_control_tab.c` to review the code changes (succeeded).
- Committed the change with `git commit -m "Restore tab style flags when assigning tab item images"` (succeeded).
- Verified the commit and working tree with `git show --stat --oneline HEAD` and `git status --short` (succeeded), and no automated build or unit tests were executed for this targeted fix.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69948d0fb5e0832ca05e84ee99fb4855)