### PR TITLE
Fix REG_SZ size passed to RegSetValueEx in wbWriteRegistryKey

### DIFF
--- a/wb/wb_winsys.c
+++ b/wb/wb_winsys.c
@@ -1217,7 +1217,8 @@ BOOL wbWriteRegistryKey(LPCTSTR pszKey, LPTSTR pszSubKey, LPTSTR pszEntry, LPCTS
 	}
 	else if (bString && pszValue)
 	{ // Create a string value
-		if (RegSetValueEx(hKey, pszEntry, 0, REG_SZ, (BYTE *)pszValue, wcslen(pszValue)) != ERROR_SUCCESS)
+		/* Win32 expects REG_SZ size in bytes, including the trailing NUL terminator. */
+		if (RegSetValueEx(hKey, pszEntry, 0, REG_SZ, (BYTE *)pszValue, (DWORD)((wcslen(pszValue) + 1) * sizeof(WCHAR))) != ERROR_SUCCESS)
 			return FALSE;
 	}
 	else


### PR DESCRIPTION
### Motivation
- Ensure `RegSetValueEx` is given the correct byte length for `REG_SZ` values so the stored string includes the terminating NUL and is written correctly.

### Description
- In `wb/wb_winsys.c` updated the `bString && pszValue` branch to call `RegSetValueEx(hKey, pszEntry, 0, REG_SZ, (BYTE *)pszValue, (DWORD)((wcslen(pszValue) + 1) * sizeof(WCHAR)))` and added a short comment noting that Win32 expects the byte length including the trailing NUL, leaving the `REG_DWORD` branch unchanged.

### Testing
- Ran `rg -n "RegSetValueEx\(.*REG_SZ|RegSetValueExW\(.*REG_SZ|RegSetValueExA\(.*REG_SZ" wb` to confirm duplicate occurrences (the other `RegSetValueExW` already used a byte-length including NUL) and committed the change with `git commit` successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69949baf8c8c832c8caa6f501fdfa328)