### PR TITLE
Use calendar notification payload timestamps in WM_NOTIFY

### DIFF
--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -14,6 +14,7 @@
 #include "wb.h"
 #include <string.h>   // For stricmp()
 #include <stdlib.h>   // For atol()
+#include <time.h>     // For time_t
 #include <shellapi.h> // For Shell_NotifyIcon()
 #include <mmsystem.h> // For timeSetEvent() and timeKillEvent
 
@@ -49,7 +50,6 @@ BOOL SetTaskBarIcon(HWND hwnd, BOOL bModify);
 // External
 
 extern PWBOBJ AssignHandlerToTabs(HWND hwndParent, LPDWORD pszObj, LPCTSTR pszHandler);
-extern DWORD GetCalendarTime(PWBOBJ pwbo);
 extern LRESULT CALLBACK BrowserWndProc(HWND hwnd, UINT64 uMsg, WPARAM wParam, LPARAM lParam);
 extern BOOL RegisterImageButtonClass(void);
 extern BOOL RegisterSplitterClass(void);
@@ -67,6 +67,7 @@ static DWORD CenterWindow(HWND hwndMovable, HWND hwndFixed);
 static BOOL CALLBACK EnumWindowsProc(HWND hWnd, LPARAM lParam);
 static DWORD GetUniqueStringId(LPCTSTR szStr);
 static UINT64 CallListViewColorHandler(LPTSTR pszHandler, LPDWORD pszHandlerObj, PWBOBJ pwbobj, LPNMHDR pnmh, LPNMLVCUSTOMDRAW lplvcd, int iSubItem, LISTVIEWCOLOR *plvc);
+static time_t CalendarNotifySelToUnixTime(const SYSTEMTIME *lpSysTime);
 
 // Procedures for WinBinder classes
 
@@ -104,6 +105,41 @@ static HWND hStatusBar = NULL;
 static HWND hwndListView = NULL;
 PWBOBJ pwndMain = NULL;
 LISTVIEWCOLOR test;
+
+static time_t CalendarNotifySelToUnixTime(const SYSTEMTIME *lpSysTime)
+{
+	SYSTEMTIME stSelection;
+	FILETIME fileTime;
+	TIME_ZONE_INFORMATION timeZoneInfo;
+	DWORD timeZoneResult;
+	LONG_PTR ll;
+	LONG_PTR bias;
+
+	if (!lpSysTime)
+		return 0;
+
+	stSelection = *lpSysTime;
+	stSelection.wHour = 0;
+	stSelection.wMinute = 0;
+	stSelection.wSecond = 0;
+	stSelection.wMilliseconds = 0;
+
+	if (!SystemTimeToFileTime(&stSelection, &fileTime))
+		return 0;
+
+	ll = fileTime.dwHighDateTime;
+	ll <<= 32;
+	ll += (ULONG_PTR)fileTime.dwLowDateTime;
+	ll -= 116444736000000000LL;
+
+	bias = 0;
+	timeZoneResult = GetTimeZoneInformation(&timeZoneInfo);
+	bias = timeZoneInfo.Bias;
+	if (timeZoneResult == TIME_ZONE_ID_DAYLIGHT)
+		bias += timeZoneInfo.DaylightBias;
+
+	return (time_t)(ll / 10000000) + (time_t)(60 * bias);
+}
 
 //------------------------------------------------------------- PUBLIC FUNCTIONS
 
@@ -911,16 +947,19 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPAR
 
                 case Calendar:
                 {
-                    PWBOBJ pwbobj;
+                    LPNMSELCHANGE pnmSelChange;
+                    time_t selectedTime;
 
-                    pwbobj = wbGetWBObj(hCtrl);
-                    if (!pwbobj)
-                        break;
+                    pnmSelChange = (LPNMSELCHANGE)lParam;
 
                     switch (((LPNMHDR)lParam)->code)
                     {
                     case MCN_SELCHANGE:
-                        CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, GetCalendarTime(pwbobj), 0, 0);
+                    case MCN_SELECT:
+                        // Use the timestamp from the notification payload to avoid delayed callbacks caused by
+                        // re-querying the calendar control state after the selection notification is dispatched.
+                        selectedTime = CalendarNotifySelToUnixTime(&pnmSelChange->stSelStart);
+                        CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, selectedTime, 0, 0);
                         break;
                     }
                 }


### PR DESCRIPTION
### Motivation
- Selection callbacks for the Calendar control could receive a delayed timestamp when the control state was re-queried, causing responsiveness issues.
- The calendar notification payload already includes the selected date/time (`stSelStart`), which can be converted to Unix time immediately and more reliably.
- Handling both `MCN_SELECT` and `MCN_SELCHANGE` increases responsiveness and compatibility with different control behaviors.
- Preserve the existing callback contract (same parameter positions) while supplying an event-derived timestamp.

### Description
- Added `#include <time.h>` and implemented `static time_t CalendarNotifySelToUnixTime(const SYSTEMTIME *lpSysTime)` to convert the `SYSTEMTIME` in the notification to Unix time using `SystemTimeToFileTime` and applying the same timezone-bias logic used elsewhere.
- Updated `WM_NOTIFY` → `case Calendar` to cast `lParam` to `LPNMSELCHANGE` and read `pnmSelChange->stSelStart` instead of re-querying the control.
- Handle both `MCN_SELCHANGE` and `MCN_SELECT` notification codes and pass the computed Unix timestamp to the callback via the unchanged `CALL_CALLBACK(idFrom, timestamp, 0, 0)` signature.
- Added a comment explaining why the notification payload is preferred over re-querying control state, and removed the now-unused `GetCalendarTime` extern from this file.

### Testing
- Ran `rg -n "GetCalendarTime\(|CalendarNotifySelToUnixTime|MCN_SELECT|LPNMSELCHANGE" wb/wb_window.c` to confirm symbols were updated (succeeded).
- Inspected diffs with `git diff -- wb/wb_window.c` to verify intended changes (succeeded).
- Confirmed working tree status with `git status --short` and committed the changes with `git commit` (succeeded).
- No additional automated unit tests were present or run; change is limited to notification handling and helper conversion logic.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6995d6c411d0832c95161a62a7bff9b5)