### PR TITLE
Avoid CS_PARENTDC in WBDEFCLASSSTYLE to fix title bar caption painting

### DIFF
--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -21,7 +21,12 @@
 //-------------------------------------------------------------------- CONSTANTS
 
 #define MAXWINNAME 256
-#define WBDEFCLASSSTYLE (CS_DBLCLKS | CS_PARENTDC)
+/*
+Avoid CS_PARENTDC on top-level WinBinder window classes.
+It can cause non-client title rendering anomalies on modern Windows where
+caption text is logically set (WM_SETTEXT/GetWindowText) but not painted.
+*/
+#define WBDEFCLASSSTYLE (CS_DBLCLKS)
 #define DEFAULT_WIN_STYLE (WS_POPUP | WS_MINIMIZEBOX | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_MAXIMIZEBOX | WS_CAPTION | WS_BORDER | WS_SYSMENU | WS_THICKFRAME)
 #define CUSTOM_MESSAGE_NAME "@WB_win32_%d_%s"
 


### PR DESCRIPTION
### Motivation
- Some Windows environments exhibited non-client title text not being painted even though `WM_SETTEXT`/`GetWindowText` reported the caption, and `CS_PARENTDC` on top-level classes can trigger such painting anomalies.

### Description
- Remove `CS_PARENTDC` from `WBDEFCLASSSTYLE` in `wb/wb_window.c` and retain `CS_DBLCLKS`.
- Add an explanatory comment above the `WBDEFCLASSSTYLE` definition documenting why `CS_PARENTDC` is avoided for top-level WinBinder windows.

### Testing
- Applied the patch to `wb/wb_window.c` using the project patch tool and the operation completed successfully.
- Verified the change with `git diff -- wb/wb_window.c` to confirm the macro update (succeeded).
- Located all usages with `rg -n "WBDEFCLASSSTYLE" wb/wb_window.c` to ensure references remain consistent (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998653c9f6c832c807d1c98f660fce2)