### PR TITLE
Fix title bar caption painting: remove CS_PARENTDC and force non-client redraw after SetWindowText

### DIFF
--- a/wb/wb_control.c
+++ b/wb/wb_control.c
@@ -1043,6 +1043,21 @@ BOOL wbSetText(PWBOBJ pwbo, LPCTSTR pszSourceText, int nItem, BOOL bTooltip)
 			else
 				return SetWindowText(pwbo->hwnd, pszText);
 
+		case AppWindow:
+		case ModalDialog:
+		case ModelessDialog:
+		case PopupWindow:
+		case ResizableWindow:
+		case ToolDialog:
+		{
+			BOOL bSet = SetWindowText(pwbo->hwnd, pszText);
+			if (bSet)
+			{
+				RedrawWindow(pwbo->hwnd, NULL, NULL, RDW_FRAME | RDW_INVALIDATE | RDW_UPDATENOW);
+			}
+			return bSet;
+		}
+
 		default:
 
 			return SetWindowText(pwbo->hwnd, pszText);

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -21,7 +21,12 @@
 //-------------------------------------------------------------------- CONSTANTS
 
 #define MAXWINNAME 256
-#define WBDEFCLASSSTYLE (CS_DBLCLKS | CS_PARENTDC)
+/*
+Avoid CS_PARENTDC on top-level WinBinder window classes.
+It can cause non-client title rendering anomalies on modern Windows where
+caption text is logically set (WM_SETTEXT/GetWindowText) but not painted.
+*/
+#define WBDEFCLASSSTYLE (CS_DBLCLKS)
 #define DEFAULT_WIN_STYLE (WS_POPUP | WS_MINIMIZEBOX | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_MAXIMIZEBOX | WS_CAPTION | WS_BORDER | WS_SYSMENU | WS_THICKFRAME)
 #define CUSTOM_MESSAGE_NAME "@WB_win32_%d_%s"
 


### PR DESCRIPTION
### Motivation
- Some Windows configurations showed a blank title bar even though `WM_SETTEXT`/`GetWindowText` reported the caption, indicating the non-client area was not being repainted.
- `CS_PARENTDC` on top-level classes can trigger non-client painting anomalies, so it is avoided for WinBinder top-level window classes.
- For cases where the caption text is updated but not visible, forcing a non-client repaint after `SetWindowText()` ensures the title bar is actually redrawn.

### Description
- Remove `CS_PARENTDC` from `WBDEFCLASSSTYLE` in `wb/wb_window.c` and add a comment explaining the reason for avoiding it on top-level WinBinder windows.
- Modify `wbSetText()` in `wb/wb_control.c` to explicitly handle top-level classes (`AppWindow`, `ModalDialog`, `ModelessDialog`, `PopupWindow`, `ResizableWindow`, `ToolDialog`) by calling `SetWindowText()` and, if successful, forcing a non-client repaint with `RedrawWindow(..., RDW_FRAME | RDW_INVALIDATE | RDW_UPDATENOW)`.
- Preserve existing behavior for controls and non-top-level classes.

### Testing
- Inspected `wb/wb_window.c` with `sed` to confirm the `WBDEFCLASSSTYLE` macro change (succeeded).
- Applied and validated the edit to `wb/wb_control.c` via the patch script, confirmed the `RedrawWindow` insertion with `git diff -- wb/wb_control.c` and `nl -ba wb/wb_control.c | sed -n '1032,1072p'` (succeeded).
- Committed the changes with `git commit -m "Force non-client redraw after setting top-level window text"` and verified repository state using `git status --short; git log --oneline -2` (succeeded).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6998653c9f6c832c807d1c98f660fce2)