### PR TITLE
Remove CS_DBLCLKS from wbCreateWindow default window styles

### DIFF
--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -201,22 +201,22 @@ PWBOBJ wbCreateWindow(PWBOBJ pwboParent, UINT64 uWinBinderClass, LPCTSTR pszCapt
 
 	case AppWindow: // Fixed size main window
 		pszClass = (BITTEST(dwWBStyle, WBC_CUSTOMDRAW) ? OWNERDRAWN_WINDOW_CLASS : MAIN_WINDOW_CLASS);
-		dwStyle = dwStyle ? dwStyle : WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_VISIBLE | WS_CLIPCHILDREN | WS_MINIMIZEBOX | CS_DBLCLKS;
+		dwStyle = dwStyle ? dwStyle : WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_VISIBLE | WS_CLIPCHILDREN | WS_MINIMIZEBOX;
 		break;
 
 	case ResizableWindow: // Resizable main window
 		pszClass = (BITTEST(dwWBStyle, WBC_CUSTOMDRAW) ? OWNERDRAWN_WINDOW_CLASS : MAIN_WINDOW_CLASS);
-		dwStyle = dwStyle ? dwStyle : WS_OVERLAPPEDWINDOW | WS_CAPTION | WS_SYSMENU | WS_VISIBLE | WS_CLIPCHILDREN | WS_SIZEBOX | CS_DBLCLKS;
+		dwStyle = dwStyle ? dwStyle : WS_OVERLAPPEDWINDOW | WS_CAPTION | WS_SYSMENU | WS_VISIBLE | WS_CLIPCHILDREN | WS_SIZEBOX;
 		break;
 
 	case PopupWindow: // Fixed size main window with no minimize/maximize button
 		pszClass = (BITTEST(dwWBStyle, WBC_CUSTOMDRAW) ? OWNERDRAWN_WINDOW_CLASS : MAIN_WINDOW_CLASS);
-		dwStyle = dwStyle ? dwStyle : WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_VISIBLE | WS_CLIPCHILDREN | CS_DBLCLKS;
+		dwStyle = dwStyle ? dwStyle : WS_OVERLAPPED | WS_CAPTION | WS_SYSMENU | WS_VISIBLE | WS_CLIPCHILDREN;
 		break;
 
 	case NakedWindow: // Fixed size borderless window
 		pszClass = (BITTEST(dwWBStyle, WBC_CUSTOMDRAW) ? OWNERDRAWN_NAKED_CLASS : NAKED_WINDOW_CLASS);
-		dwStyle = dwStyle ? dwStyle : WS_POPUP | WS_SYSMENU | WS_MINIMIZEBOX | WS_VISIBLE | WS_CLIPCHILDREN | CS_DBLCLKS;
+		dwStyle = dwStyle ? dwStyle : WS_POPUP | WS_SYSMENU | WS_MINIMIZEBOX | WS_VISIBLE | WS_CLIPCHILDREN;
 		if (BITTEST(dwWBStyle, WBC_BORDER))
 			dwExStyle |= WS_EX_DLGMODALFRAME;
 		//pwbo->style |= WBC_CUSTOMDRAW;				// All naked windows are owner-drawn
@@ -227,18 +227,18 @@ PWBOBJ wbCreateWindow(PWBOBJ pwboParent, UINT64 uWinBinderClass, LPCTSTR pszCapt
 
 	case ModalDialog: // Modal dialog box
 		pszClass = MODAL_WINDOW_CLASS;
-		dwStyle = dwStyle ? dwStyle : WS_POPUP | WS_SYSMENU | WS_CAPTION | WS_VISIBLE | WS_CLIPCHILDREN | DS_MODALFRAME | CS_DBLCLKS;
+		dwStyle = dwStyle ? dwStyle : WS_POPUP | WS_SYSMENU | WS_CAPTION | WS_VISIBLE | WS_CLIPCHILDREN | DS_MODALFRAME;
 		dwExStyle = dwExStyle ? dwExStyle : WS_EX_DLGMODALFRAME;
 		break;
 
 	case ModelessDialog: // Modeless dialog box
 		pszClass = MODELESS_WINDOW_CLASS;
-		dwStyle = dwStyle ? dwStyle : WS_OVERLAPPED | WS_SYSMENU | WS_CAPTION | WS_VISIBLE | WS_CLIPCHILDREN | CS_DBLCLKS;
+		dwStyle = dwStyle ? dwStyle : WS_OVERLAPPED | WS_SYSMENU | WS_CAPTION | WS_VISIBLE | WS_CLIPCHILDREN;
 		break;
 
 	case ToolDialog: // Modeless tool dialog
 		pszClass = MODELESS_WINDOW_CLASS;
-		dwStyle = dwStyle ? dwStyle : WS_POPUP | WS_SYSMENU | WS_CAPTION | WS_VISIBLE | WS_CLIPCHILDREN | CS_DBLCLKS;
+		dwStyle = dwStyle ? dwStyle : WS_POPUP | WS_SYSMENU | WS_CAPTION | WS_VISIBLE | WS_CLIPCHILDREN;
 		dwExStyle = dwExStyle ? dwExStyle : WS_EX_TOOLWINDOW;
 		break;
 


### PR DESCRIPTION
### Motivation
- Prevent class-style bits from being mixed into per-window `dwStyle` values by keeping `CS_DBLCLKS` at class registration level where it belongs. 
- Ensure default `dwStyle` expressions produced by `wbCreateWindow()` contain only `WS_*` and dialog-style bits. 
- Harmonize double-click handling with `WBDEFCLASSSTYLE`/`WNDCLASS.style` instead of per-window style flags.

### Description
- Removed `CS_DBLCLKS` from the `dwStyle` defaults in `wbCreateWindow()` for `AppWindow`, `ResizableWindow`, `PopupWindow`, `NakedWindow`, `ModalDialog`, `ModelessDialog`, and `ToolDialog`. 
- Left `WBDEFCLASSSTYLE` (which expands to `CS_DBLCLKS`) and the `wc.style` assignments in `RegisterClasses()` unchanged so double-click handling remains a class-level property. 
- Verified the updated `dwStyle` defaults now use only `WS_*` and `DS_MODALFRAME` dialog-style bits where applicable.

### Testing
- Ran `rg -n "case (AppWindow|ResizableWindow|PopupWindow|NakedWindow|ModalDialog|ModelessDialog|ToolDialog)|dwStyle = dwStyle \? dwStyle" wb/wb_window.c` to inspect modified cases and confirm `CS_DBLCLKS` removal, which succeeded. 
- Ran `rg -n "CS_DBLCLKS" wb/wb_window.c` to confirm `CS_DBLCLKS` remains only in `WBDEFCLASSSTYLE`/class registration, which succeeded. 
- Per-file inspection of `wb/wb_window.c` lines around the changes was performed to ensure `dwStyle` expressions contain only valid `WS_*`/dialog bits, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699882a29260832cb8aa1b9d27b21036)