### PR TITLE
Fix window caption rendering regression and restore wbSendMessage width

### DIFF
--- a/wb/wb_control.c
+++ b/wb/wb_control.c
@@ -57,19 +57,19 @@ HWND CreateToolTip(PWBOBJ pwbo, LPCTSTR pszTooltip);
 
 static BOOL SetTransparentBitmap(HWND hwnd, HBITMAP hbmBits, BOOL bStatic, COLORREF clTransp);
 
-static LRESULT CALLBACK SplitterProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK SplitterProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
-static LRESULT CALLBACK FrameProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK EditBoxProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK InvisibleProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK ImageButtonProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK FrameProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK EditBoxProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK InvisibleProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK ImageButtonProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 // External
 
 extern void SetStatusBarHandle(HWND hCtrl);
 extern BOOL RegisterControlInTab(PWBOBJ pwboParent, PWBOBJ pwbo, UINT64 id, UINT64 nTab);
-extern LRESULT CALLBACK HyperLinkProc(HWND hwnd, UINT64 message, WPARAM wParam, LPARAM lParam);
-extern LRESULT CALLBACK LabelProc(HWND hwnd, UINT64 message, WPARAM wParam, LPARAM lParam);
+extern LRESULT CALLBACK HyperLinkProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
+extern LRESULT CALLBACK LabelProc(HWND hwnd, UINT message, WPARAM wParam, LPARAM lParam);
 
 typedef struct
 {
@@ -165,7 +165,7 @@ static void SplitterLayout(PWBOBJ pwbo, BOOL bFromRatio)
 }
 
 
-static LRESULT CALLBACK SplitterProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK SplitterProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	PWBOBJ pwbo = (PWBOBJ)GetWindowLongPtr(hwnd, GWLP_USERDATA);
 	PSPLITTERDATA pData = pwbo ? SplitterGetData(pwbo) : NULL;
@@ -2295,7 +2295,7 @@ static BOOL SetTransparentBitmap(HWND hwnd, HBITMAP hbmBits, BOOL bStatic, COLOR
 
 // Processing routine for Frame controls
 
-static LRESULT CALLBACK FrameProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK FrameProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -2320,7 +2320,7 @@ static LRESULT CALLBACK FrameProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM l
 
 // Processing routine for EditBoxes
 
-static LRESULT CALLBACK EditBoxProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK EditBoxProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -2376,7 +2376,7 @@ static LRESULT CALLBACK EditBoxProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM
 
 // Processing routine for InvisibleAreas
 
-static LRESULT CALLBACK InvisibleProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK InvisibleProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -2427,7 +2427,7 @@ static LRESULT CALLBACK InvisibleProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPAR
 
 // Processing routine for ImageButton
 
-static LRESULT CALLBACK ImageButtonProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK ImageButtonProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	PWBOBJ pwbo;
 

--- a/wb/wb_control_html.c
+++ b/wb/wb_control_html.c
@@ -1143,7 +1143,7 @@ static void ResizeBrowser(HWND hwnd, DWORD width, DWORD height)
 
 // Message handler for the window that hosts the browser control.
 
-LRESULT CALLBACK BrowserWndProc(HWND hwnd, UINT64 uMsg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK BrowserWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam)
 {
 	switch (uMsg)
 	{

--- a/wb/wb_control_hyperlink.c
+++ b/wb/wb_control_hyperlink.c
@@ -32,7 +32,7 @@ static BOOL bUnderline = FALSE;
 // Code adapted from Neal Stublen, thanks to Davide
 // http://www.codeguru.com/Cpp/controls/staticctrl/article.php/c5803/
 
-LRESULT CALLBACK HyperLinkProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK HyperLinkProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{

--- a/wb/wb_control_label.c
+++ b/wb/wb_control_label.c
@@ -32,7 +32,7 @@ static BOOL bUnderline = FALSE;
 // Code adapted from Neal Stublen, thanks to Davide
 // http://www.codeguru.com/Cpp/controls/staticctrl/article.php/c5803/
 
-LRESULT CALLBACK LabelProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+LRESULT CALLBACK LabelProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{

--- a/wb/wb_lowlevel.c
+++ b/wb/wb_lowlevel.c
@@ -26,12 +26,12 @@ static HMODULE hLastDLL = NULL;
 LPARAM wbSendMessage(PWBOBJ pwbo, UINT64 uMsg, WPARAM wParam, LPARAM lParam)
 {
 	if ((LONG_PTR)pwbo == (LONG_PTR)HWND_BROADCAST)
-		return SendMessage(HWND_BROADCAST, uMsg, wParam, lParam);
+		return SendMessage(HWND_BROADCAST, (UINT)uMsg, wParam, lParam);
 
 	if (!pwbo || !pwbo->hwnd || !IsWindow(pwbo->hwnd))
 		return 0;
 
-	return SendMessage((HWND)pwbo->hwnd, uMsg, wParam, lParam);
+	return SendMessage((HWND)pwbo->hwnd, (UINT)uMsg, wParam, lParam);
 }
 
 /*

--- a/wb/wb_sysdlg.c
+++ b/wb/wb_sysdlg.c
@@ -29,7 +29,7 @@
 
 // Private
 
-static int CALLBACK BrowseCallbackProc(HWND hwnd, UINT64 uMsg, LPARAM lParam, LPARAM lpData);
+static int CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData);
 static LPTSTR DeleteChars(LPTSTR pszMain, UINT64 nPos, UINT64 nLength);
 static LPTSTR StripPath(LPTSTR pszFileName);
 
@@ -306,7 +306,7 @@ int wbSysDlgFont(PWBOBJ pwboParent, LPCTSTR pszTitle, PFONT pfont)
 
 /* Callback function for the dialog box Browse For Folder */
 
-static int CALLBACK BrowseCallbackProc(HWND hwnd, UINT64 uMsg, LPARAM lParam, LPARAM lpData)
+static int CALLBACK BrowseCallbackProc(HWND hwnd, UINT uMsg, LPARAM lParam, LPARAM lpData)
 {
 	switch (uMsg)
 	{

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -50,7 +50,7 @@ BOOL SetTaskBarIcon(HWND hwnd, BOOL bModify);
 // External
 
 extern PWBOBJ AssignHandlerToTabs(HWND hwndParent, LPDWORD pszObj, LPCTSTR pszHandler);
-extern LRESULT CALLBACK BrowserWndProc(HWND hwnd, UINT64 uMsg, WPARAM wParam, LPARAM lParam);
+extern LRESULT CALLBACK BrowserWndProc(HWND hwnd, UINT uMsg, WPARAM wParam, LPARAM lParam);
 extern BOOL RegisterImageButtonClass(void);
 extern BOOL RegisterSplitterClass(void);
 HWND CreateToolTip(PWBOBJ pwbo, LPCTSTR pszTooltip);
@@ -89,14 +89,14 @@ static time_t CalendarNotifySelToUnixTime(const SYSTEMTIME *lpSysTime);
 
 // Procedures for WinBinder classes
 
-static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK MainWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK OwnerDrawnWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK OwnerDrawnNakedWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK NakedWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK ModelessWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK ModalWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
-static LRESULT CALLBACK TabPageProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK MainWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK OwnerDrawnWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK OwnerDrawnNakedWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK NakedWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK ModelessWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK ModalWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
+static LRESULT CALLBACK TabPageProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam);
 
 //----------------------------------------------------------------------- TYPES
 
@@ -261,6 +261,12 @@ PWBOBJ wbCreateWindow(PWBOBJ pwboParent, UINT64 uWinBinderClass, LPCTSTR pszCapt
 
 	if (!pwbo->hwnd)
 		return NULL;
+
+	/*
+	Re-apply caption text after creation to ensure non-client title rendering
+	is refreshed consistently across x86/x64 builds and different window classes.
+	*/
+	SetWindowText(pwbo->hwnd, szWindowName);
 
 	// Assigns pwndMain and the window ID
 
@@ -825,7 +831,7 @@ BOOL RegisterClasses(void)
 
 */
 
-static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	static HWND hTBWnd = NULL; // Handle of toolbar window
 
@@ -884,7 +890,7 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPAR
                 break;
             }  else if (!_wcsicmp(szClass, TOOLTIPS_CLASS))  { // Tooltip
 
-                if (((LPNMHDR)lParam)->code == (UINT64)TTN_NEEDTEXT)
+                if (((LPNMHDR)lParam)->code == TTN_NEEDTEXT)
                 {
                     if (hTBWnd)
                     {
@@ -918,7 +924,7 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPAR
 
                 case Spinner:
 
-                    if (((LPNMHDR)lParam)->code == (UINT64)UDN_DELTAPOS)
+                    if (((LPNMHDR)lParam)->code == UDN_DELTAPOS)
                     {
                         CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, 0, 0, 0);
                     }
@@ -934,7 +940,7 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPAR
                             CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, WBC_DBLCLICK, 0, 0);
                         break;
 
-                    case (UINT64)TVN_SELCHANGED:
+                    case TVN_SELCHANGED:
                         CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, 0, 0, 0);
                         break;
                     }
@@ -942,7 +948,7 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPAR
 
                 case TabControl:
 
-                    if (((LPNMHDR)lParam)->code == (UINT64)TCN_SELCHANGE)
+                    if (((LPNMHDR)lParam)->code == TCN_SELCHANGE)
                     {
 
                         HWND hTab = ((LPNMHDR)lParam)->hwndFrom;
@@ -1547,7 +1553,7 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPAR
 
 /* Main window class processing */
 
-static LRESULT CALLBACK MainWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK MainWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -1856,7 +1862,7 @@ LRESULT ProcessCustomDraw(LPARAM lParam)
 
 // Owner-drawn window class: subclasses MainWndProc
 
-static LRESULT CALLBACK OwnerDrawnWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK OwnerDrawnWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -1960,7 +1966,7 @@ static LRESULT CALLBACK OwnerDrawnWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, 
 
 // Naked window class: subclasses MainWndProc
 
-static LRESULT CALLBACK NakedWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK NakedWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -2000,7 +2006,7 @@ static LRESULT CALLBACK NakedWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARA
 
 // Owner-drawn naked window class: subclasses NakedWndProc, OwnerDrawnWndProc
 
-static LRESULT CALLBACK OwnerDrawnNakedWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK OwnerDrawnNakedWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -2015,7 +2021,7 @@ static LRESULT CALLBACK OwnerDrawnNakedWndProc(HWND hwnd, UINT64 msg, WPARAM wPa
 
 // The word "modal" here is not quite true: these are not "real" modal dialog boxes
 
-static LRESULT CALLBACK ModalWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK ModalWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -2081,7 +2087,7 @@ static LRESULT CALLBACK ModalWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARA
 	return DefDlgProc(hwnd, msg, wParam, lParam);
 }
 
-static LRESULT CALLBACK ModelessWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK ModelessWndProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{
@@ -2113,7 +2119,7 @@ static LRESULT CALLBACK ModelessWndProc(HWND hwnd, UINT64 msg, WPARAM wParam, LP
 
 // Processes messages for tab pages
 
-static LRESULT CALLBACK TabPageProc(HWND hwnd, UINT64 msg, WPARAM wParam, LPARAM lParam)
+static LRESULT CALLBACK TabPageProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM lParam)
 {
 	switch (msg)
 	{

--- a/wb/wb_winsys.c
+++ b/wb/wb_winsys.c
@@ -66,7 +66,7 @@ LPTSTR MakeWinPath(LPTSTR pszPath);
 // External
 
 extern BOOL RegisterClasses(void);
-extern char *WideChar2Utf8(LPCTSTR wcs, __int64 *len);
+extern char *WideChar2Utf8(LPCTSTR wcs, int *len);
 
 //------------------------------------------------------------- PUBLIC FUNCTIONS
 


### PR DESCRIPTION
### Motivation
- A recent normalization of message/callback integer widths caused a visible regression where window titles were not painted in the non-client title bar despite appearing in Task Manager. 
- The public helper `wbSendMessage` was narrowed to a native `UINT` in the earlier change which broke compatibility with existing callers that expect wider integer message values.

### Description
- Re-applied the window caption after creation by calling `SetWindowText(pwbo->hwnd, szWindowName);` immediately after a successful `CreateWindowEx` in `wbCreateWindow` to force non-client title rendering to be refreshed (`wb/wb_window.c`).
- Restored the public `wbSendMessage` signature to `LPARAM wbSendMessage(PWBOBJ pwbo, UINT64 uMsg, WPARAM wParam, LPARAM lParam);` in `wb/wb.h` and the implementation in `wb/wb_lowlevel.c` so the API remains compatible with code that expects 64-bit message values.
- Kept correct platform behavior by casting the `UINT64` `uMsg` to the native `UINT` only at the Win32 boundary when calling `SendMessage` inside `wbSendMessage` (`SendMessage(..., (UINT)uMsg, ...)`).
- Updated the PHP binding call site in `phpwb_lowlevel.c` to pass `msg` as `UINT64` again so the extension-level call matches the restored API contract.

### Testing
- Ran whitespace/static checks with `git diff --check` which returned no issues and the checks passed. 
- Performed focused code searches with `rg` for remaining `wbSendMessage`/`UINT64` and legacy callback prototypes which showed only a historical commented prototype remaining; the targeted patterns returned no unintended matches.
- Verified the presence of the new `SetWindowText` line and the restored `wbSendMessage` signature in the modified files and found them consistent with the intended fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6994bd5af734832ca727ab2db88493a2)