### PR TITLE
Harden clipboard and string handling paths

### DIFF
--- a/phpwb_bitmap.c
+++ b/phpwb_bitmap.c
@@ -216,6 +216,7 @@ ZEND_FUNCTION(wb_screenshot)
     char *filename = NULL;
     size_t filename_len;
     wchar_t* wstr = NULL;
+    LONG_PTR result;
 
     ZEND_PARSE_PARAMETERS_START(0, 1)
         Z_PARAM_OPTIONAL
@@ -225,17 +226,27 @@ ZEND_FUNCTION(wb_screenshot)
     // If filename is not NULL, convert it to wide string
     if(filename != NULL) {
         int wchars_num = MultiByteToWideChar(CP_UTF8, 0, filename, -1, NULL, 0);
+        if (wchars_num <= 0){
+            RETURN_BOOL(FALSE);
+        }
         wstr = malloc(wchars_num * sizeof(wchar_t));
-        MultiByteToWideChar(CP_UTF8, 0, filename, -1, wstr, wchars_num);
+        if (!wstr){
+            RETURN_BOOL(FALSE);
+        }
+        if (!MultiByteToWideChar(CP_UTF8, 0, filename, -1, wstr, wchars_num)){
+            free(wstr);
+            RETURN_BOOL(FALSE);
+        }
     }
 
     // Pass filename (as wide string) or NULL to CaptureScreen
-    RETURN_LONG((LONG_PTR)CaptureScreen(wstr));
+    result = (LONG_PTR)CaptureScreen(wstr);
 
-    // If wstr was allocated, free it
     if(wstr != NULL) {
         free(wstr);
     }
+
+    RETURN_LONG(result);
 }
 
 

--- a/phpwb_winsys.c
+++ b/phpwb_winsys.c
@@ -351,7 +351,7 @@ ZEND_FUNCTION(wb_get_system_info)
 	char *s;
 	size_t s_len;
 	BOOL isstr;
-	LONG_PTR res;
+	LONG_PTR res = -1;
 	char strval[1024];
 
 	TCHAR szVal[1024];
@@ -361,6 +361,10 @@ ZEND_FUNCTION(wb_get_system_info)
 	ZEND_PARSE_PARAMETERS_START(1, 1)
 		Z_PARAM_STRING_OR_NULL(s,s_len)
 	ZEND_PARSE_PARAMETERS_END();
+
+	if (!s){
+		RETURN_NULL();
+	}
 
 	if (!stricmp(s, "extensionpath"))
 	{
@@ -377,7 +381,11 @@ ZEND_FUNCTION(wb_get_system_info)
 
 		// Assemble the final string
 		wbGetSystemInfo(TEXT("exepath"), &isstr, szVal, 1023);
-		wcscat(szVal, szValue);
+		if (wcslen(szVal) + wcslen(szValue) >= 1023){
+			wbFree(szValue);
+			RETURN_NULL();
+		}
+		wcsncat(szVal, szValue, 1023 - wcslen(szVal));
 		MakeWinPath(szVal);
 		wbFree(szValue);
 
@@ -664,17 +672,35 @@ ZEND_FUNCTION(wb_get_clipboard)
 
 ZEND_FUNCTION(wb_get_clipboard)
 {
-    char * buffer = NULL;
+	HANDLE hData = NULL;
+	char *buffer = NULL;
+	SIZE_T data_size = 0;
+	SIZE_T data_len = 0;
 
-    if ( OpenClipboard(NULL) )
-    {
-        HANDLE hData = GetClipboardData( CF_TEXT );
-        char * buffer = (char*)GlobalLock( hData );
-        GlobalUnlock( hData );
-        CloseClipboard();
-        RETURN_STRING(buffer);
-    }
-    RETURN_NULL();
+	if (!OpenClipboard(NULL)){
+		RETURN_NULL();
+	}
+
+	hData = GetClipboardData(CF_TEXT);
+	if (!hData){
+		CloseClipboard();
+		RETURN_NULL();
+	}
+
+	buffer = (char *)GlobalLock(hData);
+	if (!buffer){
+		CloseClipboard();
+		RETURN_NULL();
+	}
+
+	data_size = GlobalSize(hData);
+	while (data_len < data_size && buffer[data_len]){
+		data_len++;
+	}
+
+	RETVAL_STRINGL(buffer, data_len);
+	GlobalUnlock(hData);
+	CloseClipboard();
 }
 
 ZEND_FUNCTION(wb_set_clipboard)
@@ -696,32 +722,73 @@ ZEND_FUNCTION(wb_set_clipboard)
 
 	if (OpenClipboard(NULL))
 	{
+		if (!EmptyClipboard()){
+			CloseClipboard();
+			RETURN_BOOL(FALSE);
+		}
+
 		hdata = GlobalAlloc(GMEM_MOVEABLE, size + 1);
+		if (!hdata){
+			CloseClipboard();
+			RETURN_BOOL(FALSE);
+		}
+
 		clipcopy = (LPTSTR)GlobalLock(hdata);
+		if (!clipcopy){
+			GlobalFree(hdata);
+			CloseClipboard();
+			RETURN_BOOL(FALSE);
+		}
+
 		memcpy(clipcopy, clip, size);
+		clipcopy[size] = '\0';
+		GlobalUnlock(hdata);
 
 		if (SetClipboardData(CF_TEXT, hdata))
 		{
-			GlobalUnlock(hdata);
-			GlobalFree(hdata);
 			size = size * 2;
-			wclip = (WCHAR *)emalloc(size + 1);
+			wclip = (WCHAR *)emalloc(size + 2);
+			if (!wclip){
+				CloseClipboard();
+				RETURN_BOOL(FALSE);
+			}
 
 			if (!UTF8ToUnicode16(clip, wclip, size + 2)){
-				printf("Conversion failed\n");
+				efree(wclip);
+				CloseClipboard();
+				RETURN_BOOL(FALSE);
 			}
 			hwdata = GlobalAlloc(GMEM_MOVEABLE, size + 2);
+			if (!hwdata){
+				efree(wclip);
+				CloseClipboard();
+				RETURN_BOOL(FALSE);
+			}
+
 			wclipcopy = (LPTSTR)GlobalLock(hwdata);
+			if (!wclipcopy){
+				GlobalFree(hwdata);
+				efree(wclip);
+				CloseClipboard();
+				RETURN_BOOL(FALSE);
+			}
+
 			memcpy(wclipcopy, wclip, size);
-			SetClipboardData(CF_UNICODETEXT, hwdata);
+			((WCHAR *)wclipcopy)[size / sizeof(WCHAR)] = L'\0';
 			GlobalUnlock(hwdata);
-			GlobalFree(hwdata);
+
+			if (!SetClipboardData(CF_UNICODETEXT, hwdata)){
+				GlobalFree(hwdata);
+				efree(wclip);
+				CloseClipboard();
+				RETURN_BOOL(FALSE);
+			}
+
 			efree(wclip);
 			success = TRUE;
 		}
 		else
 		{
-			GlobalUnlock(hdata);
 			GlobalFree(hdata);
 		}
 	}


### PR DESCRIPTION
## Summary
- fixed `wb_get_clipboard` to safely copy clipboard contents before unlock/close and handle null API returns
- hardened `wb_set_clipboard` by validating allocations/locks, emptying clipboard first, correctly NUL-terminating text payloads, and respecting clipboard ownership after successful `SetClipboardData`
- prevented `wb_get_system_info` null-input crash and bounded `extensionpath` concatenation to avoid fixed-buffer overflow
- fixed `wb_screenshot` heap leak by freeing conversion buffers before return and adding conversion/allocation checks

## Security impact
These changes address multiple obvious memory-safety and robustness issues:
- use-after-unlock / invalid read risk in clipboard retrieval
- potential clipboard handle misuse and invalid frees after ownership transfer
- null dereference and possible fixed-buffer overflow in system info path assembly
- repeated-call memory leak that could be abused for resource exhaustion

## Notes
- No runtime tests were executed in this environment; this was validated by static inspection and targeted code review.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699acfc77f50832c8703ed7ec835679d)