### PR TITLE
feat: complete ScintillaEdit Phase 5 — autocomplete, calltips and whitespace/EOL toggles

### DIFF
--- a/docs/manual/classes/scintillaedit.html
+++ b/docs/manual/classes/scintillaedit.html
@@ -1,0 +1,33 @@
+<html>
+
+<head>
+<title>ScintillaEdit class</title>
+<meta name="generator" content="Namo WebEditor v5.0">
+<link rel="stylesheet" href="../help.css">
+</head>
+
+<body>
+<!--KW:
+ScintillaEdit
+Class,ScintillaEdit
+Control class,ScintillaEdit
+-->
+<h2>ScintillaEdit</h2>
+<p>ScintillaEdit is a source-code editing control backed by the Scintilla runtime.</p>
+
+<h1>Windows class</h1>
+<p>Scintilla</p>
+
+<h1>Description</h1>
+<p>This class provides a text editing surface suitable for code. Phase 3 adds PHP-editor setup support via <code>wb_scintilla_apply_php_preset()</code>, plus lexer/keyword/style configuration helpers (<code>wb_scintilla_set_lexer()</code>, <code>wb_scintilla_set_keywords()</code>, <code>wb_scintilla_set_style()</code>). Phase 4 adds callback notification mapping for editor events: <code>WBC_SCN_MODIFIED</code>, <code>WBC_SCN_UPDATEUI</code>, <code>WBC_SCN_MARGINCLICK</code>, and <code>WBC_SCN_CHARADDED</code>. Phase 5 adds IDE ergonomics helpers for autocomplete/calltips and visibility toggles for whitespace and EOL markers.</p>
+<p><b>Runtime dependency:</b> <code>SciLexer.dll</code> must be available at startup. If the runtime is missing, ScintillaEdit controls cannot be created.</p>
+
+<h1>See also</h1>
+<p><a href="../functions/wb_create_control.html">wb_create_control()</a><br>
+<a href="../reference/classes_control.html">Control classes</a><br>
+<a href="../examples/scintilla_basic.php">scintilla_basic.php</a><br>
+<code>WBC_SCLEX_HTML</code>, <code>WBC_SC_STYLE_DEFAULT</code>, <code>WBC_SC_STYLE_LINENUMBER</code>, <code>WBC_SCN_MODIFIED</code>, <code>WBC_SCN_UPDATEUI</code>, <code>WBC_SCN_MARGINCLICK</code>, <code>WBC_SCN_CHARADDED</code><br><code>wb_scintilla_autocomplete_show()</code>, <code>wb_scintilla_show_php_autocomplete()</code>, <code>wb_scintilla_calltip_show()</code>, <code>wb_scintilla_set_whitespace_view()</code>, <code>wb_scintilla_set_eol_view()</code></p>
+
+</body>
+
+</html>

--- a/docs/manual/examples/scintilla_basic.php
+++ b/docs/manual/examples/scintilla_basic.php
@@ -30,12 +30,12 @@ wb_scintilla_set_eol_view($editor, false);
 
 // Optional fine-tuning after preset
 wb_scintilla_set_line_numbers($editor, true, 56);
-wb_scintilla_set_style($editor, WBC_SC_STYLE_LINENUMBER, RGB(110, 110, 110), RGB(244, 244, 244));
+wb_scintilla_set_style($editor, WBC_SC_STYLE_LINENUMBER, DARKGRAY, LIGHTGRAY);
 
 wb_set_handler($win, "process_main");
 wb_main_loop();
 
-function process_main($window, $id, $ctrl = NULL, $param = NULL)
+function process_main($window, $id, $ctrl = 0, $param1 = 0, $param2 = 0, $param3 = 0)
 {
     switch ($id) {
         case IDOK:
@@ -46,19 +46,17 @@ function process_main($window, $id, $ctrl = NULL, $param = NULL)
 
     // Scintilla Phase 4 notifications
     if ($id === 101) {
-        if ($param === WBC_SCN_MODIFIED) {
+        if ($param1 === WBC_SCN_MODIFIED) {
             wb_set_text($window, "ScintillaEdit MVP* (modified)");
-        } elseif ($param === WBC_SCN_MARGINCLICK) {
+        } elseif ($param1 === WBC_SCN_MARGINCLICK) {
             // Placeholder hook for fold/margin interactions
-        } elseif ($param === WBC_SCN_CHARADDED) {
-            // Minimal Phase 5 autocomplete trigger demo
-            $text = wb_scintilla_get_text($ctrl);
-            $len = strlen($text);
-            if ($len > 0) {
-                $ch = $text[$len - 1];
-                if ($ch === '$' || $ch === ':' || $ch === '>') {
-                    wb_scintilla_show_php_autocomplete($ctrl, $ch);
-                }
+        } elseif ($param1 === WBC_SCN_CHARADDED) {
+            // Minimal Phase 5 autocomplete/calltip trigger demo
+            $ch = chr((int)$param2);
+            if ($ch === '$' || $ch === ':' || $ch === '>') {
+                wb_scintilla_show_php_autocomplete($ctrl, $ch);
+            } elseif ($ch === '(') {
+                wb_scintilla_calltip_show($ctrl, "functionName(arg1, arg2)");
             }
         }
     }

--- a/docs/manual/examples/scintilla_basic.php
+++ b/docs/manual/examples/scintilla_basic.php
@@ -1,0 +1,65 @@
+<?php
+
+$win = wb_create_window(NULL, AppWindow, "ScintillaEdit MVP", WBC_CENTER, WBC_CENTER, 900, 640);
+
+$editor = wb_create_control(
+    $win,
+    ScintillaEdit,
+    "",
+    10,
+    10,
+    870,
+    580,
+    101,
+    WBC_VISIBLE | WBC_BORDER | WBC_NOTIFY,
+    WBC_SCN_MODIFIED | WBC_SCN_UPDATEUI | WBC_SCN_MARGINCLICK | WBC_SCN_CHARADDED
+);
+
+if (!$editor) {
+    wb_message_box($win, "ScintillaEdit could not be created. Ensure SciLexer.dll is available.", "Scintilla runtime missing", WBC_STOP);
+    wb_destroy_window($win);
+    return;
+}
+
+wb_scintilla_set_text($editor, "<?php\n\n// ScintillaEdit Phase 2 sample\nfunction greet(string $name): void\n{\n    echo \"Hello {$name}\\n\";\n}\n\ngreet('Scintilla');\n");
+
+
+wb_scintilla_apply_php_preset($editor);
+wb_scintilla_set_whitespace_view($editor, false);
+wb_scintilla_set_eol_view($editor, false);
+
+// Optional fine-tuning after preset
+wb_scintilla_set_line_numbers($editor, true, 56);
+wb_scintilla_set_style($editor, WBC_SC_STYLE_LINENUMBER, RGB(110, 110, 110), RGB(244, 244, 244));
+
+wb_set_handler($win, "process_main");
+wb_main_loop();
+
+function process_main($window, $id, $ctrl = NULL, $param = NULL)
+{
+    switch ($id) {
+        case IDOK:
+        case IDCANCEL:
+            wb_destroy_window($window);
+            return;
+    }
+
+    // Scintilla Phase 4 notifications
+    if ($id === 101) {
+        if ($param === WBC_SCN_MODIFIED) {
+            wb_set_text($window, "ScintillaEdit MVP* (modified)");
+        } elseif ($param === WBC_SCN_MARGINCLICK) {
+            // Placeholder hook for fold/margin interactions
+        } elseif ($param === WBC_SCN_CHARADDED) {
+            // Minimal Phase 5 autocomplete trigger demo
+            $text = wb_scintilla_get_text($ctrl);
+            $len = strlen($text);
+            if ($len > 0) {
+                $ch = $text[$len - 1];
+                if ($ch === '$' || $ch === ':' || $ch === '>') {
+                    wb_scintilla_show_php_autocomplete($ctrl, $ch);
+                }
+            }
+        }
+    }
+}

--- a/docs/manual/examples/scintilla_basic.php
+++ b/docs/manual/examples/scintilla_basic.php
@@ -1,6 +1,6 @@
 <?php
 
-$win = wb_create_window(NULL, AppWindow, "ScintillaEdit API demo", WBC_CENTER, WBC_CENTER, 980, 700);
+$win = wb_create_window(NULL, AppWindow, "ScintillaEdit API demo", WBC_CENTER, WBC_CENTER, 1040, 760);
 
 $editor = wb_create_control(
     $win,
@@ -8,14 +8,21 @@ $editor = wb_create_control(
     "",
     10,
     10,
-    950,
-    610,
+    780,
+    700,
     101,
     WBC_VISIBLE | WBC_BORDER | WBC_NOTIFY,
     WBC_SCN_MODIFIED | WBC_SCN_UPDATEUI | WBC_SCN_MARGINCLICK | WBC_SCN_CHARADDED
 );
 
-$status = wb_create_control($win, Label, "Ready", 10, 628, 950, 24, 102, WBC_VISIBLE | WBC_BORDER);
+$status = wb_create_control($win, Label, "Ready", 10, 714, 1010, 26, 102, WBC_VISIBLE | WBC_BORDER);
+
+$chkReadonly     = wb_create_control($win, CheckBox, "Read-only",          810,  20, 200, 24, 201, WBC_VISIBLE);
+$chkLineNumbers  = wb_create_control($win, CheckBox, "Line numbers",       810,  50, 200, 24, 202, WBC_VISIBLE);
+$chkIndentGuides = wb_create_control($win, CheckBox, "Indent guides",      810,  80, 200, 24, 203, WBC_VISIBLE);
+$chkUseTabs      = wb_create_control($win, CheckBox, "Use tabs",           810, 110, 200, 24, 204, WBC_VISIBLE);
+$chkWhitespace   = wb_create_control($win, CheckBox, "Show whitespace",    810, 140, 200, 24, 205, WBC_VISIBLE);
+$chkEol          = wb_create_control($win, CheckBox, "Show EOL",           810, 170, 200, 24, 206, WBC_VISIBLE);
 
 if (!$editor) {
     wb_message_box($win, "ScintillaEdit could not be created. Ensure SciLexer.dll is available.", "Scintilla runtime missing", WBC_STOP);
@@ -23,92 +30,101 @@ if (!$editor) {
     return;
 }
 
-// -----------------------------------------------------------------------------
-// Phase 1..5 API walkthrough (using all currently added Scintilla helpers)
-// -----------------------------------------------------------------------------
-
-// Core text APIs
+// Core setup and API walkthrough
 wb_scintilla_set_text($editor, "<?php\n\nclass Demo\n{\n    public function greet(string $name): void\n    {\n        echo \"Hello {$name}\\n\";\n    }\n}\n\n$demo = new Demo();\n$demo->greet('Scintilla');\n");
-wb_scintilla_append_text($editor, "\n// Appended with wb_scintilla_append_text()\n");
-$allText = wb_scintilla_get_text($editor);
+wb_scintilla_append_text($editor, "\n// Try typing $, :, >, ., (, ) and clicking margins\n");
 
-// Selection/caret/navigation APIs
-wb_scintilla_goto_line($editor, 0);
-$lineCount = wb_scintilla_get_line_count($editor);
-$currentPos = wb_scintilla_get_current_pos($editor);
-wb_scintilla_set_selection($editor, 0, min(20, strlen($allText)));
-$selStart = wb_scintilla_get_selection_start($editor);
-$selEnd = wb_scintilla_get_selection_end($editor);
-wb_set_text($status, "Lines: {$lineCount}, Pos: {$currentPos}, Sel: {$selStart}-{$selEnd}");
-
-// Edit command APIs
-wb_scintilla_copy($editor);
-wb_scintilla_cut($editor);
-wb_scintilla_paste($editor);
-wb_scintilla_undo($editor);
-wb_scintilla_redo($editor);
-
-// Readonly toggle API
-wb_scintilla_set_readonly($editor, true);
-wb_scintilla_set_readonly($editor, false);
-
-// Preset + lexer/style/keywords APIs
 wb_scintilla_apply_php_preset($editor);
 wb_scintilla_set_lexer($editor, WBC_SCLEX_HTML);
 wb_scintilla_set_keywords($editor, 0, "class function public private protected return if else foreach while try catch throw");
 wb_scintilla_set_style($editor, WBC_SC_STYLE_LINENUMBER, DARKGRAY, LIGHTGRAY);
 
-// Indentation/layout APIs
 wb_scintilla_set_tab_width($editor, 4);
-wb_scintilla_set_use_tabs($editor, false);
-wb_scintilla_set_indent_guides($editor, true);
 wb_scintilla_set_line_numbers($editor, true, 56);
-
-// Visibility APIs
+wb_scintilla_set_indent_guides($editor, true);
+wb_scintilla_set_use_tabs($editor, false);
 wb_scintilla_set_whitespace_view($editor, false);
 wb_scintilla_set_eol_view($editor, false);
 
-// Clear + restore demo for wb_scintilla_clear_all
-$backup = wb_scintilla_get_text($editor);
-wb_scintilla_clear_all($editor);
-wb_scintilla_set_text($editor, $backup);
+// Set checkbox defaults to match initial editor configuration
+wb_set_state($chkLineNumbers, 0, true);
+wb_set_state($chkIndentGuides, 0, true);
 
 wb_set_handler($win, "process_main");
 wb_main_loop();
 
+function update_status($window, $editor, $prefix = "")
+{
+    $pos = wb_scintilla_get_current_pos($editor);
+    $selStart = wb_scintilla_get_selection_start($editor);
+    $selEnd = wb_scintilla_get_selection_end($editor);
+    $lines = wb_scintilla_get_line_count($editor);
+    wb_set_text($window, "ScintillaEdit API demo" . $prefix);
+    wb_set_text(wb_get_control($window, 102), "Lines: {$lines}, Pos: {$pos}, Sel: {$selStart}-{$selEnd}");
+}
+
 function process_main($window, $id, $ctrl = 0, $param1 = 0, $param2 = 0, $param3 = 0)
 {
-    // Close window
+    $editor = wb_get_control($window, 101);
+
     if ($id === IDCANCEL || $id === IDOK) {
         wb_destroy_window($window);
         return;
     }
 
-    if ($id !== 101) {
-        return;
+    // Checkbox-driven configuration tests
+    switch ($id) {
+        case 201:
+            wb_scintilla_set_readonly($editor, wb_get_value($ctrl) ? true : false);
+            break;
+        case 202:
+            wb_scintilla_set_line_numbers($editor, wb_get_value($ctrl) ? true : false, 56);
+            break;
+        case 203:
+            wb_scintilla_set_indent_guides($editor, wb_get_value($ctrl) ? true : false);
+            break;
+        case 204:
+            wb_scintilla_set_use_tabs($editor, wb_get_value($ctrl) ? true : false);
+            break;
+        case 205:
+            wb_scintilla_set_whitespace_view($editor, wb_get_value($ctrl) ? true : false);
+            break;
+        case 206:
+            wb_scintilla_set_eol_view($editor, wb_get_value($ctrl) ? true : false);
+            break;
     }
 
     // Scintilla notifications
+    if ($id !== 101) {
+        update_status($window, $editor);
+        return;
+    }
+
     if ($param1 === WBC_SCN_MODIFIED) {
-        wb_set_text($window, "ScintillaEdit API demo* (modified)");
+        update_status($window, $editor, "* (modified)");
+    } elseif ($param1 === WBC_SCN_UPDATEUI) {
+        update_status($window, $editor);
     } elseif ($param1 === WBC_SCN_MARGINCLICK) {
-        wb_set_text($window, "ScintillaEdit API demo (margin click)");
+        update_status($window, $editor, " (margin click)");
     } elseif ($param1 === WBC_SCN_CHARADDED) {
-        $ch = chr((int)$param2);
+        // Fallback on current char-at-caret to avoid dependency on notification payload
+        $text = wb_scintilla_get_text($editor);
+        $len = strlen($text);
+        $ch = $len > 0 ? $text[$len - 1] : '';
 
-        // PHP-specific convenience autocomplete helper
         if ($ch === '$' || $ch === ':' || $ch === '>') {
-            wb_scintilla_show_php_autocomplete($ctrl, $ch);
+            wb_scintilla_show_php_autocomplete($editor, $ch);
         }
 
-        // Generic autocomplete/calltip helpers
         if ($ch === '.') {
-            wb_scintilla_autocomplete_show($ctrl, "count current date diff filter format join map merge reduce split", 0);
+            wb_scintilla_autocomplete_show($editor, "count current date diff filter format join map merge reduce split", 0);
         } elseif ($ch === '(') {
-            wb_scintilla_calltip_show($ctrl, "functionName(arg1, arg2)");
+            wb_scintilla_calltip_show($editor, "functionName(arg1, arg2)");
         } elseif ($ch === ')') {
-            wb_scintilla_calltip_cancel($ctrl);
-            wb_scintilla_autocomplete_cancel($ctrl);
+            wb_scintilla_calltip_cancel($editor);
+            wb_scintilla_autocomplete_cancel($editor);
         }
+
+        update_status($window, $editor);
     }
 }

--- a/docs/manual/examples/scintilla_basic.php
+++ b/docs/manual/examples/scintilla_basic.php
@@ -1,6 +1,6 @@
 <?php
 
-$win = wb_create_window(NULL, AppWindow, "ScintillaEdit API demo", WBC_CENTER, WBC_CENTER, 1040, 760);
+$win = wb_create_window(0, AppWindow, "ScintillaEdit API demo", WBC_CENTER, WBC_CENTER, 1040, 820);
 
 $editor = wb_create_control(
     $win,
@@ -9,13 +9,13 @@ $editor = wb_create_control(
     10,
     10,
     780,
-    700,
+    740,
     101,
     WBC_VISIBLE | WBC_BORDER | WBC_NOTIFY,
     WBC_SCN_MODIFIED | WBC_SCN_UPDATEUI | WBC_SCN_MARGINCLICK | WBC_SCN_CHARADDED
 );
 
-$status = wb_create_control($win, Label, "Ready", 10, 714, 1010, 26, 102, WBC_VISIBLE | WBC_BORDER);
+$status = wb_create_control($win, Label, "Ready", 10, 764, 1010, 40, 102, WBC_VISIBLE | WBC_BORDER | WBC_MULTILINE);
 
 $chkReadonly     = wb_create_control($win, CheckBox, "Read-only",          810,  20, 200, 24, 201, WBC_VISIBLE);
 $chkLineNumbers  = wb_create_control($win, CheckBox, "Line numbers",       810,  50, 200, 24, 202, WBC_VISIBLE);
@@ -30,8 +30,29 @@ if (!$editor) {
     return;
 }
 
-// Core setup and API walkthrough
-wb_scintilla_set_text($editor, "<?php\n\nclass Demo\n{\n    public function greet(string $name): void\n    {\n        echo \"Hello {$name}\\n\";\n    }\n}\n\n$demo = new Demo();\n$demo->greet('Scintilla');\n");
+// Build broad autocomplete sources for all WinBinder functions/constants.
+$wbFunctions = array_values(array_filter(get_defined_functions()['internal'], fn($f) => stripos($f, 'wb_') === 0));
+$wbConstants = array_keys(array_filter(get_defined_constants(), fn($k) => stripos($k, 'WBC_') === 0 || stripos($k, 'AppWindow') === 0 || stripos($k, 'ScintillaEdit') === 0, ARRAY_FILTER_USE_KEY));
+$GLOBALS['wb_scintilla_autocomplete_list'] = implode(' ', array_unique(array_merge($wbFunctions, $wbConstants)));
+
+$demoText = <<<'PHP'
+<?php
+
+class Demo
+{
+    public function greet(string $name): void
+    {
+        echo "Hello {$name}\n";
+    }
+}
+
+$demo = new Demo();
+$demo->greet('Scintilla');
+
+// Type wb_ or WBC_ then '.' for broad autocomplete.
+PHP;
+
+wb_scintilla_set_text($editor, $demoText);
 wb_scintilla_append_text($editor, "\n// Try typing $, :, >, ., (, ) and clicking margins\n");
 
 wb_scintilla_apply_php_preset($editor);
@@ -46,7 +67,6 @@ wb_scintilla_set_use_tabs($editor, false);
 wb_scintilla_set_whitespace_view($editor, false);
 wb_scintilla_set_eol_view($editor, false);
 
-// Set checkbox defaults to match initial editor configuration
 wb_set_state($chkLineNumbers, 0, true);
 wb_set_state($chkIndentGuides, 0, true);
 
@@ -60,7 +80,18 @@ function update_status($window, $editor, $prefix = "")
     $selEnd = wb_scintilla_get_selection_end($editor);
     $lines = wb_scintilla_get_line_count($editor);
     wb_set_text($window, "ScintillaEdit API demo" . $prefix);
-    wb_set_text(wb_get_control($window, 102), "Lines: {$lines}, Pos: {$pos}, Sel: {$selStart}-{$selEnd}");
+
+    $ro = wb_get_value(wb_get_control($window, 201)) ? 'ON' : 'OFF';
+    $ln = wb_get_value(wb_get_control($window, 202)) ? 'ON' : 'OFF';
+    $ig = wb_get_value(wb_get_control($window, 203)) ? 'ON' : 'OFF';
+    $ut = wb_get_value(wb_get_control($window, 204)) ? 'ON' : 'OFF';
+    $ws = wb_get_value(wb_get_control($window, 205)) ? 'ON' : 'OFF';
+    $eol = wb_get_value(wb_get_control($window, 206)) ? 'ON' : 'OFF';
+
+    wb_set_text(
+        wb_get_control($window, 102),
+        "Lines: {$lines}, Pos: {$pos}, Sel: {$selStart}-{$selEnd}\nRO={$ro} LN={$ln} IG={$ig} TABS={$ut} WS={$ws} EOL={$eol}"
+    );
 }
 
 function process_main($window, $id, $ctrl = 0, $param1 = 0, $param2 = 0, $param3 = 0)
@@ -72,29 +103,33 @@ function process_main($window, $id, $ctrl = 0, $param1 = 0, $param2 = 0, $param3
         return;
     }
 
-    // Checkbox-driven configuration tests
     switch ($id) {
         case 201:
             wb_scintilla_set_readonly($editor, wb_get_value($ctrl) ? true : false);
-            break;
+            update_status($window, $editor, " (readonly toggled)");
+            return;
         case 202:
             wb_scintilla_set_line_numbers($editor, wb_get_value($ctrl) ? true : false, 56);
-            break;
+            update_status($window, $editor, " (line numbers toggled)");
+            return;
         case 203:
             wb_scintilla_set_indent_guides($editor, wb_get_value($ctrl) ? true : false);
-            break;
+            update_status($window, $editor, " (indent guides toggled)");
+            return;
         case 204:
             wb_scintilla_set_use_tabs($editor, wb_get_value($ctrl) ? true : false);
-            break;
+            update_status($window, $editor, " (tabs toggled)");
+            return;
         case 205:
             wb_scintilla_set_whitespace_view($editor, wb_get_value($ctrl) ? true : false);
-            break;
+            update_status($window, $editor, " (whitespace toggled)");
+            return;
         case 206:
             wb_scintilla_set_eol_view($editor, wb_get_value($ctrl) ? true : false);
-            break;
+            update_status($window, $editor, " (EOL toggled)");
+            return;
     }
 
-    // Scintilla notifications
     if ($id !== 101) {
         update_status($window, $editor);
         return;
@@ -107,7 +142,6 @@ function process_main($window, $id, $ctrl = 0, $param1 = 0, $param2 = 0, $param3
     } elseif ($param1 === WBC_SCN_MARGINCLICK) {
         update_status($window, $editor, " (margin click)");
     } elseif ($param1 === WBC_SCN_CHARADDED) {
-        // Fallback on current char-at-caret to avoid dependency on notification payload
         $text = wb_scintilla_get_text($editor);
         $len = strlen($text);
         $ch = $len > 0 ? $text[$len - 1] : '';
@@ -117,9 +151,9 @@ function process_main($window, $id, $ctrl = 0, $param1 = 0, $param2 = 0, $param3
         }
 
         if ($ch === '.') {
-            wb_scintilla_autocomplete_show($editor, "count current date diff filter format join map merge reduce split", 0);
+            wb_scintilla_autocomplete_show($editor, $GLOBALS['wb_scintilla_autocomplete_list'], 0);
         } elseif ($ch === '(') {
-            wb_scintilla_calltip_show($editor, "functionName(arg1, arg2)");
+            wb_scintilla_calltip_show($editor, "wb_function_name(arg1, arg2)\nConstants: WBC_* | Classes: AppWindow..ScintillaEdit");
         } elseif ($ch === ')') {
             wb_scintilla_calltip_cancel($editor);
             wb_scintilla_autocomplete_cancel($editor);

--- a/docs/manual/examples/scintilla_basic.php
+++ b/docs/manual/examples/scintilla_basic.php
@@ -1,6 +1,6 @@
 <?php
 
-$win = wb_create_window(NULL, AppWindow, "ScintillaEdit MVP", WBC_CENTER, WBC_CENTER, 900, 640);
+$win = wb_create_window(NULL, AppWindow, "ScintillaEdit API demo", WBC_CENTER, WBC_CENTER, 980, 700);
 
 $editor = wb_create_control(
     $win,
@@ -8,12 +8,14 @@ $editor = wb_create_control(
     "",
     10,
     10,
-    870,
-    580,
+    950,
+    610,
     101,
     WBC_VISIBLE | WBC_BORDER | WBC_NOTIFY,
     WBC_SCN_MODIFIED | WBC_SCN_UPDATEUI | WBC_SCN_MARGINCLICK | WBC_SCN_CHARADDED
 );
+
+$status = wb_create_control($win, Label, "Ready", 10, 628, 950, 24, 102, WBC_VISIBLE | WBC_BORDER);
 
 if (!$editor) {
     wb_message_box($win, "ScintillaEdit could not be created. Ensure SciLexer.dll is available.", "Scintilla runtime missing", WBC_STOP);
@@ -21,43 +23,92 @@ if (!$editor) {
     return;
 }
 
-wb_scintilla_set_text($editor, "<?php\n\n// ScintillaEdit Phase 2 sample\nfunction greet(string $name): void\n{\n    echo \"Hello {$name}\\n\";\n}\n\ngreet('Scintilla');\n");
+// -----------------------------------------------------------------------------
+// Phase 1..5 API walkthrough (using all currently added Scintilla helpers)
+// -----------------------------------------------------------------------------
 
+// Core text APIs
+wb_scintilla_set_text($editor, "<?php\n\nclass Demo\n{\n    public function greet(string $name): void\n    {\n        echo \"Hello {$name}\\n\";\n    }\n}\n\n$demo = new Demo();\n$demo->greet('Scintilla');\n");
+wb_scintilla_append_text($editor, "\n// Appended with wb_scintilla_append_text()\n");
+$allText = wb_scintilla_get_text($editor);
 
+// Selection/caret/navigation APIs
+wb_scintilla_goto_line($editor, 0);
+$lineCount = wb_scintilla_get_line_count($editor);
+$currentPos = wb_scintilla_get_current_pos($editor);
+wb_scintilla_set_selection($editor, 0, min(20, strlen($allText)));
+$selStart = wb_scintilla_get_selection_start($editor);
+$selEnd = wb_scintilla_get_selection_end($editor);
+wb_set_text($status, "Lines: {$lineCount}, Pos: {$currentPos}, Sel: {$selStart}-{$selEnd}");
+
+// Edit command APIs
+wb_scintilla_copy($editor);
+wb_scintilla_cut($editor);
+wb_scintilla_paste($editor);
+wb_scintilla_undo($editor);
+wb_scintilla_redo($editor);
+
+// Readonly toggle API
+wb_scintilla_set_readonly($editor, true);
+wb_scintilla_set_readonly($editor, false);
+
+// Preset + lexer/style/keywords APIs
 wb_scintilla_apply_php_preset($editor);
+wb_scintilla_set_lexer($editor, WBC_SCLEX_HTML);
+wb_scintilla_set_keywords($editor, 0, "class function public private protected return if else foreach while try catch throw");
+wb_scintilla_set_style($editor, WBC_SC_STYLE_LINENUMBER, DARKGRAY, LIGHTGRAY);
+
+// Indentation/layout APIs
+wb_scintilla_set_tab_width($editor, 4);
+wb_scintilla_set_use_tabs($editor, false);
+wb_scintilla_set_indent_guides($editor, true);
+wb_scintilla_set_line_numbers($editor, true, 56);
+
+// Visibility APIs
 wb_scintilla_set_whitespace_view($editor, false);
 wb_scintilla_set_eol_view($editor, false);
 
-// Optional fine-tuning after preset
-wb_scintilla_set_line_numbers($editor, true, 56);
-wb_scintilla_set_style($editor, WBC_SC_STYLE_LINENUMBER, DARKGRAY, LIGHTGRAY);
+// Clear + restore demo for wb_scintilla_clear_all
+$backup = wb_scintilla_get_text($editor);
+wb_scintilla_clear_all($editor);
+wb_scintilla_set_text($editor, $backup);
 
 wb_set_handler($win, "process_main");
 wb_main_loop();
 
 function process_main($window, $id, $ctrl = 0, $param1 = 0, $param2 = 0, $param3 = 0)
 {
-    switch ($id) {
-        case IDOK:
-        case IDCANCEL:
-            wb_destroy_window($window);
-            return;
+    // Close window
+    if ($id === IDCANCEL || $id === IDOK) {
+        wb_destroy_window($window);
+        return;
     }
 
-    // Scintilla Phase 4 notifications
-    if ($id === 101) {
-        if ($param1 === WBC_SCN_MODIFIED) {
-            wb_set_text($window, "ScintillaEdit MVP* (modified)");
-        } elseif ($param1 === WBC_SCN_MARGINCLICK) {
-            // Placeholder hook for fold/margin interactions
-        } elseif ($param1 === WBC_SCN_CHARADDED) {
-            // Minimal Phase 5 autocomplete/calltip trigger demo
-            $ch = chr((int)$param2);
-            if ($ch === '$' || $ch === ':' || $ch === '>') {
-                wb_scintilla_show_php_autocomplete($ctrl, $ch);
-            } elseif ($ch === '(') {
-                wb_scintilla_calltip_show($ctrl, "functionName(arg1, arg2)");
-            }
+    if ($id !== 101) {
+        return;
+    }
+
+    // Scintilla notifications
+    if ($param1 === WBC_SCN_MODIFIED) {
+        wb_set_text($window, "ScintillaEdit API demo* (modified)");
+    } elseif ($param1 === WBC_SCN_MARGINCLICK) {
+        wb_set_text($window, "ScintillaEdit API demo (margin click)");
+    } elseif ($param1 === WBC_SCN_CHARADDED) {
+        $ch = chr((int)$param2);
+
+        // PHP-specific convenience autocomplete helper
+        if ($ch === '$' || $ch === ':' || $ch === '>') {
+            wb_scintilla_show_php_autocomplete($ctrl, $ch);
+        }
+
+        // Generic autocomplete/calltip helpers
+        if ($ch === '.') {
+            wb_scintilla_autocomplete_show($ctrl, "count current date diff filter format join map merge reduce split", 0);
+        } elseif ($ch === '(') {
+            wb_scintilla_calltip_show($ctrl, "functionName(arg1, arg2)");
+        } elseif ($ch === ')') {
+            wb_scintilla_calltip_cancel($ctrl);
+            wb_scintilla_autocomplete_cancel($ctrl);
         }
     }
 }

--- a/docs/manual/reference/classes_control.html
+++ b/docs/manual/reference/classes_control.html
@@ -295,6 +295,17 @@ a parent window</p>
     </tr>
     <tr>
         <td width="118">
+            <p><a href="../classes/scintillaedit.html">ScintillaEdit</a></p>
+        </td>
+        <td width="126">
+            <p>Scintilla</p>
+        </td>
+        <td width="841">
+            <p>Source-code editor control powered by SciLexer.dll</p>
+        </td>
+    </tr>
+    <tr>
+        <td width="118">
             <p><a href="../classes/splitter.html">Splitter</a></p>
         </td>
         <td width="126">

--- a/docs/scintilla_phased_delivery_plan.md
+++ b/docs/scintilla_phased_delivery_plan.md
@@ -1,0 +1,108 @@
+# Scintilla Control for WinBinder (PHP Editor Focus): Phased Delivery Plan
+
+## Goal
+Add a native Scintilla-backed WinBinder control with practical PHP-editor capabilities, delivered incrementally to reduce risk and keep each step shippable.
+
+## Phase 1 — Control Foundation (MVP)
+**Outcome:** A Scintilla control can be created via `wb_create_control()` and used as a plain text editor.
+
+### Scope
+- Add `ScintillaEdit` to WinBinder control class enum and validation.
+- Export PHP constant (`ScintillaEdit`) in module init.
+- Add control creation branch in `wbCreateControl()` (`class = "Scintilla"`).
+- Load `SciLexer.dll` during initialization with graceful failure handling.
+- Add minimal sample that creates the control and sets text.
+
+### Acceptance criteria
+- `wb_create_control($win, ScintillaEdit, ...)` returns a valid control.
+- Control renders and accepts typed text.
+- Missing `SciLexer.dll` fails predictably (clear warning, no crash).
+
+---
+
+## Phase 2 — Essential Editor API Surface
+**Outcome:** PHP userland can perform core editing operations without raw Win32 message plumbing.
+
+### Scope
+- Add wrappers + PHP bindings for core operations:
+  - set/get text, append text, clear all
+  - selection start/end, set selection, current position
+  - go to line, get line count
+  - read-only mode, undo/redo, cut/copy/paste
+- Add style/config helpers:
+  - tab width, tabs vs spaces, indentation guides
+  - line number margin on/off
+
+### Acceptance criteria
+- A sample script can load/save text and move caret/selection.
+- Basic editing commands work via dedicated WinBinder APIs.
+
+---
+
+## Phase 3 — PHP Editor Preset + Syntax Highlighting
+**Outcome:** Scintilla behaves like a PHP-focused code editor out of the box.
+
+### Scope
+- Add a high-level preset helper (or documented setup routine):
+  - UTF-8/code page defaults
+  - PHP lexer selection
+  - PHP keyword sets
+  - default font/theme styles
+  - folding and margin glyphs
+  - brace matching and visual cues
+- Add sample `php_editor.phpw` demonstrating preset usage.
+
+### Acceptance criteria
+- PHP syntax highlighting is functional and readable.
+- Folding and line-number gutter are enabled.
+- Sample opens as a usable PHP code editor.
+
+---
+
+## Phase 4 — Event Model for Interactive Editing
+**Outcome:** WinBinder callback pipeline exposes useful Scintilla notifications for editor workflows.
+
+### Scope
+- Handle Scintilla notifications in `WM_NOTIFY` and map to WinBinder callback events.
+- Prioritize:
+  - `SCN_MODIFIED` (dirty tracking)
+  - `SCN_UPDATEUI` (caret/selection updates)
+  - `SCN_MARGINCLICK` (fold toggles)
+  - optional `SCN_CHARADDED` (auto-indent/autocomplete triggers)
+- Export event constants for PHP callback discrimination.
+
+### Acceptance criteria
+- Callback receives distinct event codes for modified/update/margin actions.
+- A sample demonstrates dirty-state and fold-click handling.
+
+---
+
+## Phase 5 — PHP IDE Ergonomics (Nice-to-Have)
+**Outcome:** Better coding experience for everyday PHP editing.
+
+### Scope
+- Autocomplete trigger strategy for identifiers, `$`, `->`, `::`.
+- Simple call-tip support (where practical).
+- Smart indentation for braces/new lines.
+- Optional whitespace/line-ending visualization toggles.
+
+### Acceptance criteria
+- Autocomplete can be triggered with common PHP patterns.
+- Indentation behavior is predictable for block edits.
+
+---
+
+## Cross-Phase Guardrails
+- Keep each phase independently releasable.
+- Prefer small, explicit PHP APIs over one opaque “send raw message” API.
+- Add/update samples each phase to serve as executable documentation.
+- Maintain graceful behavior when Scintilla runtime is unavailable.
+
+## Suggested Delivery Order
+1. Phase 1
+2. Phase 2
+3. Phase 3
+4. Phase 4
+5. Phase 5
+
+This order ensures creation/stability first, then usability, then advanced editor ergonomics.

--- a/phpwb_control.c
+++ b/phpwb_control.c
@@ -21,6 +21,73 @@ extern BOOL DisplayHTMLPage(PWBOBJ pwbo, LPCTSTR pszWebPageName);
 extern BOOL SetProxyForWebBrowser(PWBOBJ pwbo, const char* proxyAddress);
 
 
+
+// Minimal Scintilla message/margin constants for Phase 2 API
+#ifndef SCI_GETTEXT
+#define SCI_ADDTEXT 2001
+#define SCI_GETTEXT 2182
+#define SCI_SETTEXT 2181
+#define SCI_CLEARALL 2004
+#define SCI_GETLENGTH 2006
+#define SCI_GETCURRENTPOS 2008
+#define SCI_GOTOPOS 2025
+#define SCI_GOTOLINE 2024
+#define SCI_GETANCHOR 2009
+#define SCI_SETSEL 2160
+#define SCI_GETSELECTIONSTART 2143
+#define SCI_GETSELECTIONEND 2145
+#define SCI_GETLINECOUNT 2154
+#define SCI_SETREADONLY 2171
+#define SCI_UNDO 2176
+#define SCI_REDO 2011
+#define SCI_CUT 2177
+#define SCI_COPY 2178
+#define SCI_PASTE 2179
+#define SCI_SETTABWIDTH 2036
+#define SCI_SETUSETABS 2124
+#define SCI_SETINDENTATIONGUIDES 2132
+#define SCI_SETMARGINTYPEN 2240
+#define SCI_SETMARGINWIDTHN 2242
+#define SCI_STYLESETFORE 2051
+#define SCI_STYLESETBACK 2052
+#define SCI_STYLESETBOLD 2053
+#define SCI_STYLESETITALIC 2054
+#define SCI_STYLESETSIZE 2055
+#define SCI_STYLESETFONT 2056
+#define SCI_STYLECLEARALL 2050
+#define SCI_SETLEXER 4001
+#define SCI_SETKEYWORDS 4005
+#define SCI_SETPROPERTY 4004
+#define SCI_SETCARETLINEVISIBLE 2096
+#define SCI_SETCARETLINEBACK 2098
+#define SCI_SETTABINDENTS 2260
+#define SCI_SETBACKSPACEUNINDENTS 2261
+#define SCI_SETINDENT 2122
+#define SCI_SETVIEWWS 2021
+#define SCI_SETVIEWEOL 2355
+#define SCI_AUTOCSHOW 2100
+#define SCI_AUTOCCANCEL 2101
+#define SCI_CALLTIPSHOW 2200
+#define SCI_CALLTIPCANCEL 2201
+#define SCI_SETUSETABS 2124
+#define SC_MARGIN_NUMBER 1
+#define SC_MARGIN_SYMBOL 0
+#define SCLEX_HTML 4
+#define STYLE_DEFAULT 32
+#define STYLE_LINENUMBER 33
+#define SCWS_INVISIBLE 0
+#endif
+
+static PWBOBJ wbPhpGetScintillaObj(zend_long pwbo)
+{
+	PWBOBJ obj = (PWBOBJ)pwbo;
+	if (!wbIsWBObj((void *)pwbo, TRUE))
+		return NULL;
+	if (obj->uClass != ScintillaEdit)
+		return NULL;
+	return obj;
+}
+
 //----------------------------------------------------------- EXPORTED FUNCTIONS
 
 /* Creates a window control, menu, toolbar, status bar or accelerator. */
@@ -1316,5 +1383,567 @@ ZEND_FUNCTION(wb_get_text)
 		RETURN_STRING(""); // This is a valid empty string
 	}
 }
+
+
+
+ZEND_FUNCTION(wb_scintilla_set_text)
+{
+	zend_long pwbo;
+	char *text = NULL;
+	size_t text_len = 0;
+	PWBOBJ obj;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_STRING(text, text_len)
+	ZEND_PARSE_PARAMETERS_END();
+
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+
+	SendMessage(obj->hwnd, SCI_SETTEXT, 0, (LPARAM)text);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_get_text)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	LONG_PTR len;
+	char *buffer;
+
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_NULL();
+
+	len = SendMessage(obj->hwnd, SCI_GETLENGTH, 0, 0);
+	if (len < 0)
+		RETURN_NULL();
+
+	buffer = emalloc((size_t)len + 2);
+	if (!buffer)
+		RETURN_NULL();
+
+	memset(buffer, 0, (size_t)len + 2);
+	SendMessage(obj->hwnd, SCI_GETTEXT, (WPARAM)(len + 1), (LPARAM)buffer);
+	RETVAL_STRINGL(buffer, (size_t)len);
+	efree(buffer);
+}
+
+ZEND_FUNCTION(wb_scintilla_append_text)
+{
+	zend_long pwbo;
+	char *text = NULL;
+	size_t text_len = 0;
+	PWBOBJ obj;
+
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_STRING(text, text_len)
+	ZEND_PARSE_PARAMETERS_END();
+
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+
+	SendMessage(obj->hwnd, SCI_ADDTEXT, (WPARAM)text_len, (LPARAM)text);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_clear_all)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_CLEARALL, 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_get_current_pos)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_LONG(-1);
+	RETURN_LONG((zend_long)SendMessage(obj->hwnd, SCI_GETCURRENTPOS, 0, 0));
+}
+
+ZEND_FUNCTION(wb_scintilla_set_selection)
+{
+	zend_long pwbo, start, end;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_LONG(start)
+		Z_PARAM_LONG(end)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETSEL, (WPARAM)start, (LPARAM)end);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_get_selection_start)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_LONG(-1);
+	RETURN_LONG((zend_long)SendMessage(obj->hwnd, SCI_GETSELECTIONSTART, 0, 0));
+}
+
+ZEND_FUNCTION(wb_scintilla_get_selection_end)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_LONG(-1);
+	RETURN_LONG((zend_long)SendMessage(obj->hwnd, SCI_GETSELECTIONEND, 0, 0));
+}
+
+ZEND_FUNCTION(wb_scintilla_goto_line)
+{
+	zend_long pwbo, line;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_LONG(line)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_GOTOLINE, (WPARAM)line, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_get_line_count)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_LONG(0);
+	RETURN_LONG((zend_long)SendMessage(obj->hwnd, SCI_GETLINECOUNT, 0, 0));
+}
+
+ZEND_FUNCTION(wb_scintilla_set_readonly)
+{
+	zend_long pwbo;
+	zend_bool bReadOnly;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_BOOL(bReadOnly)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETREADONLY, (WPARAM)(bReadOnly ? 1 : 0), 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_undo)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_UNDO, 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_redo)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_REDO, 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_cut)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_CUT, 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_copy)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_COPY, 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_paste)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_PASTE, 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_tab_width)
+{
+	zend_long pwbo, width;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_LONG(width)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETTABWIDTH, (WPARAM)max(1, width), 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_use_tabs)
+{
+	zend_long pwbo;
+	zend_bool useTabs;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_BOOL(useTabs)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETUSETABS, (WPARAM)(useTabs ? 1 : 0), 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_indent_guides)
+{
+	zend_long pwbo;
+	zend_bool enabled;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_BOOL(enabled)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETINDENTATIONGUIDES, (WPARAM)(enabled ? 1 : 0), 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_line_numbers)
+{
+	zend_long pwbo;
+	zend_bool enabled;
+	zend_long width = 48;
+	PWBOBJ obj;
+	zend_bool width_isnull;
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_BOOL(enabled)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG_OR_NULL(width, width_isnull)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETMARGINTYPEN, 0, SC_MARGIN_NUMBER);
+	SendMessage(obj->hwnd, SCI_SETMARGINWIDTHN, 0, enabled ? max(16, width) : 0);
+	RETURN_BOOL(TRUE);
+}
+
+
+static void wbScintillaApplyPhpPreset(PWBOBJ obj)
+{
+	const char *phpKeywords = "abstract and array as break callable case catch class clone const continue declare default do else elseif enddeclare endfor endforeach endif endswitch endwhile extends final finally fn for foreach function global goto if implements include include_once instanceof insteadof interface isset list match namespace new or print private protected public readonly require require_once return self static switch throw trait try unset use var while xor yield from";
+
+	SendMessage(obj->hwnd, SCI_SETLEXER, SCLEX_HTML, 0);
+	SendMessage(obj->hwnd, SCI_SETKEYWORDS, 1, (LPARAM)phpKeywords);
+	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"lexer.html.php", (LPARAM)"1");
+	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"fold", (LPARAM)"1");
+	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"fold.html", (LPARAM)"1");
+	SendMessage(obj->hwnd, SCI_SETMARGINTYPEN, 2, SC_MARGIN_SYMBOL);
+	SendMessage(obj->hwnd, SCI_SETMARGINWIDTHN, 2, 16);
+	SendMessage(obj->hwnd, SCI_SETTABWIDTH, 4, 0);
+	SendMessage(obj->hwnd, SCI_SETINDENT, 4, 0);
+	SendMessage(obj->hwnd, SCI_SETUSETABS, 0, 0);
+	SendMessage(obj->hwnd, SCI_SETTABINDENTS, 1, 0);
+	SendMessage(obj->hwnd, SCI_SETBACKSPACEUNINDENTS, 1, 0);
+	SendMessage(obj->hwnd, SCI_SETINDENTATIONGUIDES, 1, 0);
+	SendMessage(obj->hwnd, SCI_SETMARGINTYPEN, 0, SC_MARGIN_NUMBER);
+	SendMessage(obj->hwnd, SCI_SETMARGINWIDTHN, 0, 56);
+	SendMessage(obj->hwnd, SCI_SETCARETLINEVISIBLE, 1, 0);
+	SendMessage(obj->hwnd, SCI_SETCARETLINEBACK, RGB(245, 245, 245), 0);
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, STYLE_DEFAULT, RGB(0, 0, 0));
+	SendMessage(obj->hwnd, SCI_STYLESETBACK, STYLE_DEFAULT, RGB(255, 255, 255));
+	SendMessage(obj->hwnd, SCI_STYLESETFONT, STYLE_DEFAULT, (LPARAM)"Consolas");
+	SendMessage(obj->hwnd, SCI_STYLESETSIZE, STYLE_DEFAULT, 10);
+	SendMessage(obj->hwnd, SCI_STYLECLEARALL, 0, 0);
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, STYLE_LINENUMBER, RGB(120, 120, 120));
+	SendMessage(obj->hwnd, SCI_STYLESETBACK, STYLE_LINENUMBER, RGB(245, 245, 245));
+	SendMessage(obj->hwnd, SCI_SETVIEWWS, SCWS_INVISIBLE, 0);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_lexer)
+{
+	zend_long pwbo, lexer;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_LONG(lexer)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETLEXER, (WPARAM)lexer, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_keywords)
+{
+	zend_long pwbo, setIndex;
+	char *keywords = NULL;
+	size_t keywords_len = 0;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_LONG(setIndex)
+		Z_PARAM_STRING(keywords, keywords_len)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETKEYWORDS, (WPARAM)setIndex, (LPARAM)keywords);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_style)
+{
+	zend_long pwbo, style, foreground, background;
+	zend_bool bold = 0, italic = 0;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(4, 6)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_LONG(style)
+		Z_PARAM_LONG(foreground)
+		Z_PARAM_LONG(background)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(bold)
+		Z_PARAM_BOOL(italic)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, (WPARAM)style, (LPARAM)foreground);
+	SendMessage(obj->hwnd, SCI_STYLESETBACK, (WPARAM)style, (LPARAM)background);
+	SendMessage(obj->hwnd, SCI_STYLESETBOLD, (WPARAM)style, (LPARAM)(bold ? 1 : 0));
+	SendMessage(obj->hwnd, SCI_STYLESETITALIC, (WPARAM)style, (LPARAM)(italic ? 1 : 0));
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_apply_php_preset)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	wbScintillaApplyPhpPreset(obj);
+	RETURN_BOOL(TRUE);
+}
+
+
+ZEND_FUNCTION(wb_scintilla_autocomplete_show)
+{
+	zend_long pwbo;
+	char *list = NULL;
+	size_t list_len = 0;
+	zend_long lenEntered = 0;
+	zend_bool len_isnull;
+	PWBOBJ obj;
+
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_STRING(list, list_len)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG_OR_NULL(lenEntered, len_isnull)
+	ZEND_PARSE_PARAMETERS_END();
+
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+
+	SendMessage(obj->hwnd, SCI_AUTOCSHOW, (WPARAM)max(0, lenEntered), (LPARAM)list);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_autocomplete_cancel)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_AUTOCCANCEL, 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_calltip_show)
+{
+	zend_long pwbo;
+	char *text = NULL;
+	size_t text_len = 0;
+	zend_long position = -1;
+	zend_bool pos_isnull;
+	PWBOBJ obj;
+
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_STRING(text, text_len)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_LONG_OR_NULL(position, pos_isnull)
+	ZEND_PARSE_PARAMETERS_END();
+
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+
+	if (position < 0)
+		position = (zend_long)SendMessage(obj->hwnd, SCI_GETCURRENTPOS, 0, 0);
+
+	SendMessage(obj->hwnd, SCI_CALLTIPSHOW, (WPARAM)position, (LPARAM)text);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_calltip_cancel)
+{
+	zend_long pwbo;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(1, 1)
+		Z_PARAM_LONG(pwbo)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_CALLTIPCANCEL, 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_whitespace_view)
+{
+	zend_long pwbo;
+	zend_bool enabled;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_BOOL(enabled)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETVIEWWS, enabled ? 1 : 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_set_eol_view)
+{
+	zend_long pwbo;
+	zend_bool enabled;
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_BOOL(enabled)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+	SendMessage(obj->hwnd, SCI_SETVIEWEOL, enabled ? 1 : 0, 0);
+	RETURN_BOOL(TRUE);
+}
+
+ZEND_FUNCTION(wb_scintilla_show_php_autocomplete)
+{
+	zend_long pwbo;
+	char *trigger = NULL;
+	size_t trigger_len = 0;
+	const char *list = "echo implode explode print_r var_dump strlen strpos substr preg_match preg_replace array_map array_filter in_array isset empty";
+	PWBOBJ obj;
+	ZEND_PARSE_PARAMETERS_START(2, 2)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_STRING(trigger, trigger_len)
+	ZEND_PARSE_PARAMETERS_END();
+	obj = wbPhpGetScintillaObj(pwbo);
+	if (!obj)
+		RETURN_BOOL(FALSE);
+
+	if (trigger_len && (trigger[0] == ':' || trigger[0] == '>'))
+		list = "self static parent __construct __invoke __toString public protected private function";
+	else if (trigger_len && trigger[0] == '$')
+		list = "_GET _POST _SERVER _REQUEST _SESSION _COOKIE _FILES _ENV";
+
+	SendMessage(obj->hwnd, SCI_AUTOCSHOW, 0, (LPARAM)list);
+	RETURN_BOOL(TRUE);
+}
+
 
 //------------------------------------------------------------------ END OF FILE

--- a/phpwb_control.c
+++ b/phpwb_control.c
@@ -76,6 +76,15 @@ extern BOOL SetProxyForWebBrowser(PWBOBJ pwbo, const char* proxyAddress);
 #define STYLE_DEFAULT 32
 #define STYLE_LINENUMBER 33
 #define SCWS_INVISIBLE 0
+#define SCE_HPHP_DEFAULT 118
+#define SCE_HPHP_HSTRING 121
+#define SCE_HPHP_SIMPLESTRING 122
+#define SCE_HPHP_WORD 123
+#define SCE_HPHP_NUMBER 124
+#define SCE_HPHP_VARIABLE 126
+#define SCE_HPHP_OPERATOR 127
+#define SCE_HPHP_COMMENT 128
+#define SCE_HPHP_COMMENTLINE 129
 #endif
 
 static PWBOBJ wbPhpGetScintillaObj(zend_long pwbo)
@@ -1712,7 +1721,7 @@ static void wbScintillaApplyPhpPreset(PWBOBJ obj)
 	const char *phpKeywords = "abstract and array as break callable case catch class clone const continue declare default do else elseif enddeclare endfor endforeach endif endswitch endwhile extends final finally fn for foreach function global goto if implements include include_once instanceof insteadof interface isset list match namespace new or print private protected public readonly require require_once return self static switch throw trait try unset use var while xor yield from";
 
 	SendMessage(obj->hwnd, SCI_SETLEXER, SCLEX_HTML, 0);
-	SendMessage(obj->hwnd, SCI_SETKEYWORDS, 1, (LPARAM)phpKeywords);
+	SendMessage(obj->hwnd, SCI_SETKEYWORDS, 0, (LPARAM)phpKeywords);
 	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"lexer.html.php", (LPARAM)"1");
 	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"fold", (LPARAM)"1");
 	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"fold.html", (LPARAM)"1");
@@ -1735,6 +1744,15 @@ static void wbScintillaApplyPhpPreset(PWBOBJ obj)
 	SendMessage(obj->hwnd, SCI_STYLECLEARALL, 0, 0);
 	SendMessage(obj->hwnd, SCI_STYLESETFORE, STYLE_LINENUMBER, RGB(120, 120, 120));
 	SendMessage(obj->hwnd, SCI_STYLESETBACK, STYLE_LINENUMBER, RGB(245, 245, 245));
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_WORD, RGB(0, 0, 180));
+	SendMessage(obj->hwnd, SCI_STYLESETBOLD, SCE_HPHP_WORD, 1);
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_VARIABLE, RGB(150, 0, 150));
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_NUMBER, RGB(180, 0, 0));
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_COMMENT, RGB(0, 128, 0));
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_COMMENTLINE, RGB(0, 128, 0));
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_HSTRING, RGB(163, 21, 21));
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_SIMPLESTRING, RGB(163, 21, 21));
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_OPERATOR, RGB(0, 0, 0));
 	SendMessage(obj->hwnd, SCI_SETVIEWWS, SCWS_INVISIBLE, 0);
 }
 
@@ -1926,7 +1944,7 @@ ZEND_FUNCTION(wb_scintilla_show_php_autocomplete)
 	zend_long pwbo;
 	char *trigger = NULL;
 	size_t trigger_len = 0;
-	const char *list = "echo implode explode print_r var_dump strlen strpos substr preg_match preg_replace array_map array_filter in_array isset empty";
+	const char *list = "echo implode explode print_r var_dump strlen strpos substr preg_match preg_replace array_map array_filter in_array isset empty count array_key_exists";
 	PWBOBJ obj;
 	ZEND_PARSE_PARAMETERS_START(2, 2)
 		Z_PARAM_LONG(pwbo)

--- a/phpwb_control.c
+++ b/phpwb_control.c
@@ -77,14 +77,15 @@ extern BOOL SetProxyForWebBrowser(PWBOBJ pwbo, const char* proxyAddress);
 #define STYLE_LINENUMBER 33
 #define SCWS_INVISIBLE 0
 #define SCE_HPHP_DEFAULT 118
-#define SCE_HPHP_HSTRING 121
-#define SCE_HPHP_SIMPLESTRING 122
-#define SCE_HPHP_WORD 123
-#define SCE_HPHP_NUMBER 124
-#define SCE_HPHP_VARIABLE 126
+#define SCE_HPHP_HSTRING 119
+#define SCE_HPHP_SIMPLESTRING 120
+#define SCE_HPHP_WORD 121
+#define SCE_HPHP_NUMBER 122
+#define SCE_HPHP_VARIABLE 123
+#define SCE_HPHP_COMMENT 124
+#define SCE_HPHP_COMMENTLINE 125
+#define SCE_HPHP_HSTRING_VARIABLE 126
 #define SCE_HPHP_OPERATOR 127
-#define SCE_HPHP_COMMENT 128
-#define SCE_HPHP_COMMENTLINE 129
 #endif
 
 static PWBOBJ wbPhpGetScintillaObj(zend_long pwbo)
@@ -1722,6 +1723,8 @@ static void wbScintillaApplyPhpPreset(PWBOBJ obj)
 
 	SendMessage(obj->hwnd, SCI_SETLEXER, SCLEX_HTML, 0);
 	SendMessage(obj->hwnd, SCI_SETKEYWORDS, 0, (LPARAM)phpKeywords);
+	SendMessage(obj->hwnd, SCI_SETKEYWORDS, 4, (LPARAM)phpKeywords);
+	SendMessage(obj->hwnd, SCI_SETKEYWORDS, 5, (LPARAM)phpKeywords);
 	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"lexer.html.php", (LPARAM)"1");
 	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"fold", (LPARAM)"1");
 	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"fold.html", (LPARAM)"1");
@@ -1752,6 +1755,7 @@ static void wbScintillaApplyPhpPreset(PWBOBJ obj)
 	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_COMMENTLINE, RGB(0, 128, 0));
 	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_HSTRING, RGB(163, 21, 21));
 	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_SIMPLESTRING, RGB(163, 21, 21));
+	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_HSTRING_VARIABLE, RGB(150, 0, 150));
 	SendMessage(obj->hwnd, SCI_STYLESETFORE, SCE_HPHP_OPERATOR, RGB(0, 0, 0));
 	SendMessage(obj->hwnd, SCI_SETVIEWWS, SCWS_INVISIBLE, 0);
 }

--- a/phpwb_control.c
+++ b/phpwb_control.c
@@ -29,6 +29,7 @@ extern BOOL SetProxyForWebBrowser(PWBOBJ pwbo, const char* proxyAddress);
 #define SCI_SETTEXT 2181
 #define SCI_CLEARALL 2004
 #define SCI_GETLENGTH 2006
+#define SCI_GETCHARAT 2007
 #define SCI_GETCURRENTPOS 2008
 #define SCI_GOTOPOS 2025
 #define SCI_GOTOLINE 2024
@@ -48,6 +49,7 @@ extern BOOL SetProxyForWebBrowser(PWBOBJ pwbo, const char* proxyAddress);
 #define SCI_SETINDENTATIONGUIDES 2132
 #define SCI_SETMARGINTYPEN 2240
 #define SCI_SETMARGINWIDTHN 2242
+#define SCI_SETMARGINSENSITIVEN 2246
 #define SCI_STYLESETFORE 2051
 #define SCI_STYLESETBACK 2052
 #define SCI_STYLESETBOLD 2053
@@ -1730,6 +1732,8 @@ static void wbScintillaApplyPhpPreset(PWBOBJ obj)
 	SendMessage(obj->hwnd, SCI_SETPROPERTY, (WPARAM)"fold.html", (LPARAM)"1");
 	SendMessage(obj->hwnd, SCI_SETMARGINTYPEN, 2, SC_MARGIN_SYMBOL);
 	SendMessage(obj->hwnd, SCI_SETMARGINWIDTHN, 2, 16);
+	SendMessage(obj->hwnd, SCI_SETMARGINSENSITIVEN, 0, 1);
+	SendMessage(obj->hwnd, SCI_SETMARGINSENSITIVEN, 2, 1);
 	SendMessage(obj->hwnd, SCI_SETTABWIDTH, 4, 0);
 	SendMessage(obj->hwnd, SCI_SETINDENT, 4, 0);
 	SendMessage(obj->hwnd, SCI_SETUSETABS, 0, 0);

--- a/phpwb_export.c
+++ b/phpwb_export.c
@@ -118,6 +118,37 @@ ZEND_FUNCTION(wb_set_splitter_position);
 ZEND_FUNCTION(wb_get_splitter_position);
 ZEND_FUNCTION(wb_set_splitter_panes);
 ZEND_FUNCTION(wb_set_splitter_minsize);
+ZEND_FUNCTION(wb_scintilla_set_text);
+ZEND_FUNCTION(wb_scintilla_get_text);
+ZEND_FUNCTION(wb_scintilla_append_text);
+ZEND_FUNCTION(wb_scintilla_clear_all);
+ZEND_FUNCTION(wb_scintilla_get_current_pos);
+ZEND_FUNCTION(wb_scintilla_set_selection);
+ZEND_FUNCTION(wb_scintilla_get_selection_start);
+ZEND_FUNCTION(wb_scintilla_get_selection_end);
+ZEND_FUNCTION(wb_scintilla_goto_line);
+ZEND_FUNCTION(wb_scintilla_get_line_count);
+ZEND_FUNCTION(wb_scintilla_set_readonly);
+ZEND_FUNCTION(wb_scintilla_undo);
+ZEND_FUNCTION(wb_scintilla_redo);
+ZEND_FUNCTION(wb_scintilla_cut);
+ZEND_FUNCTION(wb_scintilla_copy);
+ZEND_FUNCTION(wb_scintilla_paste);
+ZEND_FUNCTION(wb_scintilla_set_tab_width);
+ZEND_FUNCTION(wb_scintilla_set_use_tabs);
+ZEND_FUNCTION(wb_scintilla_set_indent_guides);
+ZEND_FUNCTION(wb_scintilla_set_line_numbers);
+ZEND_FUNCTION(wb_scintilla_set_lexer);
+ZEND_FUNCTION(wb_scintilla_set_keywords);
+ZEND_FUNCTION(wb_scintilla_set_style);
+ZEND_FUNCTION(wb_scintilla_apply_php_preset);
+ZEND_FUNCTION(wb_scintilla_autocomplete_show);
+ZEND_FUNCTION(wb_scintilla_autocomplete_cancel);
+ZEND_FUNCTION(wb_scintilla_calltip_show);
+ZEND_FUNCTION(wb_scintilla_calltip_cancel);
+ZEND_FUNCTION(wb_scintilla_set_whitespace_view);
+ZEND_FUNCTION(wb_scintilla_set_eol_view);
+ZEND_FUNCTION(wb_scintilla_show_php_autocomplete);
 
 // PHPWB_DRAW.C
 ZEND_FUNCTION(wb_get_pixel);
@@ -320,6 +351,37 @@ zend_function_entry winbinder_functions[] =
         ZEND_FE(wb_get_splitter_position,arginfo_wb_get_splitter_position)
         ZEND_FE(wb_set_splitter_panes,arginfo_wb_set_splitter_panes)
         ZEND_FE(wb_set_splitter_minsize,arginfo_wb_set_splitter_minsize)
+        ZEND_FE(wb_scintilla_set_text,arginfo_wb_scintilla_set_text)
+        ZEND_FE(wb_scintilla_get_text,arginfo_wb_scintilla_get_text)
+        ZEND_FE(wb_scintilla_append_text,arginfo_wb_scintilla_append_text)
+        ZEND_FE(wb_scintilla_clear_all,arginfo_wb_scintilla_clear_all)
+        ZEND_FE(wb_scintilla_get_current_pos,arginfo_wb_scintilla_get_current_pos)
+        ZEND_FE(wb_scintilla_set_selection,arginfo_wb_scintilla_set_selection)
+        ZEND_FE(wb_scintilla_get_selection_start,arginfo_wb_scintilla_get_selection_start)
+        ZEND_FE(wb_scintilla_get_selection_end,arginfo_wb_scintilla_get_selection_end)
+        ZEND_FE(wb_scintilla_goto_line,arginfo_wb_scintilla_goto_line)
+        ZEND_FE(wb_scintilla_get_line_count,arginfo_wb_scintilla_get_line_count)
+        ZEND_FE(wb_scintilla_set_readonly,arginfo_wb_scintilla_set_readonly)
+        ZEND_FE(wb_scintilla_undo,arginfo_wb_scintilla_undo)
+        ZEND_FE(wb_scintilla_redo,arginfo_wb_scintilla_redo)
+        ZEND_FE(wb_scintilla_cut,arginfo_wb_scintilla_cut)
+        ZEND_FE(wb_scintilla_copy,arginfo_wb_scintilla_copy)
+        ZEND_FE(wb_scintilla_paste,arginfo_wb_scintilla_paste)
+        ZEND_FE(wb_scintilla_set_tab_width,arginfo_wb_scintilla_set_tab_width)
+        ZEND_FE(wb_scintilla_set_use_tabs,arginfo_wb_scintilla_set_use_tabs)
+        ZEND_FE(wb_scintilla_set_indent_guides,arginfo_wb_scintilla_set_indent_guides)
+        ZEND_FE(wb_scintilla_set_line_numbers,arginfo_wb_scintilla_set_line_numbers)
+        ZEND_FE(wb_scintilla_set_lexer,arginfo_wb_scintilla_set_lexer)
+        ZEND_FE(wb_scintilla_set_keywords,arginfo_wb_scintilla_set_keywords)
+        ZEND_FE(wb_scintilla_set_style,arginfo_wb_scintilla_set_style)
+        ZEND_FE(wb_scintilla_apply_php_preset,arginfo_wb_scintilla_apply_php_preset)
+        ZEND_FE(wb_scintilla_autocomplete_show,arginfo_wb_scintilla_autocomplete_show)
+        ZEND_FE(wb_scintilla_autocomplete_cancel,arginfo_wb_scintilla_autocomplete_cancel)
+        ZEND_FE(wb_scintilla_calltip_show,arginfo_wb_scintilla_calltip_show)
+        ZEND_FE(wb_scintilla_calltip_cancel,arginfo_wb_scintilla_calltip_cancel)
+        ZEND_FE(wb_scintilla_set_whitespace_view,arginfo_wb_scintilla_set_whitespace_view)
+        ZEND_FE(wb_scintilla_set_eol_view,arginfo_wb_scintilla_set_eol_view)
+        ZEND_FE(wb_scintilla_show_php_autocomplete,arginfo_wb_scintilla_show_php_autocomplete)
 
         // PHPWB_CONTROL_LISTVIEW.C
         ZEND_FE(wb_create_listview_item,arginfo_wb_create_listview_item)
@@ -464,6 +526,7 @@ ZEND_MINIT_FUNCTION(winbinder)
 	WB_ZEND_CONST(LONG, "TabControl", TabControl)
 	WB_ZEND_CONST(LONG, "ToolBar", ToolBar)
 	WB_ZEND_CONST(LONG, "TreeView", TreeView)
+	WB_ZEND_CONST(LONG, "ScintillaEdit", ScintillaEdit)
 	WB_ZEND_CONST(LONG, "Splitter", Splitter)
 	WB_ZEND_CONST(LONG, "Timer", Timer)
 
@@ -517,6 +580,10 @@ ZEND_MINIT_FUNCTION(winbinder)
 	WB_ZEND_CONST(LONG, "WBC_REDRAW", WBC_REDRAW)
 	WB_ZEND_CONST(LONG, "WBC_HEADERSEL", WBC_HEADERSEL)
 	WB_ZEND_CONST(LONG, "WBC_DROPFILES", WBC_DROPFILES)
+	WB_ZEND_CONST(LONG, "WBC_SCN_MODIFIED", WBC_SCN_MODIFIED)
+	WB_ZEND_CONST(LONG, "WBC_SCN_UPDATEUI", WBC_SCN_UPDATEUI)
+	WB_ZEND_CONST(LONG, "WBC_SCN_MARGINCLICK", WBC_SCN_MARGINCLICK)
+	WB_ZEND_CONST(LONG, "WBC_SCN_CHARADDED", WBC_SCN_CHARADDED)
 	WB_ZEND_CONST(LONG, "WBC_LV_SELECTED", WBC_LV_SELECTED)
 
 	// Additional notification message flags
@@ -623,6 +690,11 @@ ZEND_MINIT_FUNCTION(winbinder)
  	WB_ZEND_CONST(LONG, "WBC_MAX_ITEM_STRING", 1024); // Maximum string in a ListView / TreeView
  	WB_ZEND_CONST(LONG, "WBC_MAX_TREEVIEW_LEVELS", 25); // Maximum treeview levels
  	WB_ZEND_CONST(LONG, "WBC_MAX_IMAGELIST_IMAGES", 128); // Maximum images inside a ImageList
+
+	// Scintilla lexer/style helper constants
+	WB_ZEND_CONST(LONG, "WBC_SCLEX_HTML", 4);
+	WB_ZEND_CONST(LONG, "WBC_SC_STYLE_DEFAULT", 32);
+	WB_ZEND_CONST(LONG, "WBC_SC_STYLE_LINENUMBER", 33);
 
 	// Additional
 	#include "phpwb_export_constants.c" // For Windows constants as PHP constants

--- a/phpwb_wb_arginfo.h
+++ b/phpwb_wb_arginfo.h
@@ -472,6 +472,156 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_set_splitter_minsize, 0, 3, _
 	ZEND_ARG_TYPE_INFO(0, min_pane2, IS_LONG, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_text, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_wb_scintilla_get_text, 0, 1, MAY_BE_NULL|MAY_BE_STRING)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_append_text, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_clear_all, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_get_current_pos, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_selection, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, start, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, end, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_get_selection_start, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_get_selection_end, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_goto_line, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, line, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_get_line_count, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_readonly, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, read_only, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_undo, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_redo, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_cut, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_copy, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_paste, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_tab_width, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, width, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_use_tabs, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, use_tabs, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_indent_guides, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, enabled, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_line_numbers, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, enabled, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_MASK(0, width, MAY_BE_LONG|MAY_BE_NULL, "48")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_lexer, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, lexer, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_keywords, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, set_index, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, keywords, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_style, 0, 4, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, style, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, foreground, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, background, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, bold, _IS_BOOL, 1)
+	ZEND_ARG_TYPE_INFO(0, italic, _IS_BOOL, 1)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_apply_php_preset, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_autocomplete_show, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, list, IS_STRING, 0)
+	ZEND_ARG_TYPE_MASK(0, entered_length, MAY_BE_LONG|MAY_BE_NULL, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_autocomplete_cancel, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_calltip_show, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, text, IS_STRING, 0)
+	ZEND_ARG_TYPE_MASK(0, position, MAY_BE_LONG|MAY_BE_NULL, "-1")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_calltip_cancel, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_whitespace_view, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, enabled, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_set_eol_view, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, enabled, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_scintilla_show_php_autocomplete, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, trigger, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_create_listview_item, 0, 4, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, item, IS_LONG, 0)

--- a/wb/wb.h
+++ b/wb/wb.h
@@ -177,6 +177,7 @@ enum
 	TabControl,
 	ToolBar,
 	TreeView,
+	ScintillaEdit,
 	Timer,
 	Splitter,
 };
@@ -235,6 +236,10 @@ enum
 #define WBC_HEADERSEL 0x00008000
 
 #define WBC_DROPFILES 0x00010000
+#define WBC_SCN_MODIFIED 0x00020000
+#define WBC_SCN_UPDATEUI 0x00040000
+#define WBC_SCN_MARGINCLICK 0x00080000
+#define WBC_SCN_CHARADDED 0x00100000
 
 // ListView item-changed event discriminators (callback lParam1)
 #define WBC_LV_SELECTED 0x00000001
@@ -438,6 +443,7 @@ extern HFONT hIconFont;		   // Icon font
 extern WNDPROC lpfnTabProcOld; // Original tab control procedure
 extern COLORREF clrTabs;	   // Color for tab control backgrounds
 extern HBRUSH hbrTabs;		   // Brush for tab control backgrounds
+extern BOOL bScintillaAvailable;
 
 //------------------------------------------------------------ PUBLIC PROTOTYPES
 

--- a/wb/wb_control.c
+++ b/wb/wb_control.c
@@ -476,6 +476,17 @@ PWBOBJ wbCreateControl(PWBOBJ pwboParent, UINT64 uWinBinderClass, LPCTSTR pszSou
 		dwExStyle |= WS_EX_CLIENTEDGE;
 		break;
 
+	case ScintillaEdit:
+		if (!bScintillaAvailable)
+		{
+			wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Cannot create ScintillaEdit control because SciLexer.dll was not loaded"));
+			return NULL;
+		}
+		pszClass = TEXT("Scintilla");
+		dwStyle = WS_CHILD | WS_TABSTOP | WS_VSCROLL | WS_HSCROLL | nVisible;
+		dwExStyle |= WS_EX_CLIENTEDGE;
+		break;
+
 	case ListBox:
 		pszClass = TEXT("LISTBOX");
 		dwStyle = WS_CHILD | WS_TABSTOP | WS_VSCROLL | LBS_NOTIFY | LBS_NOINTEGRALHEIGHT | nVisible;

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -1029,15 +1029,15 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
                     {
                         if (((LPNMHDR)lParam)->code == SCN_CHARADDED)
                         {
-                            CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->ch, scn->position);
+                            CALL_CALLBACK(pwbobj->id, eventType, scn->ch, scn->position);
                         }
                         else if (((LPNMHDR)lParam)->code == SCN_MARGINCLICK)
                         {
-                            CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->position, scn->margin);
+                            CALL_CALLBACK(pwbobj->id, eventType, scn->position, scn->margin);
                         }
                         else
                         {
-                            CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->position, scn->line);
+                            CALL_CALLBACK(pwbobj->id, eventType, scn->position, scn->line);
                         }
                     }
                 }

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -1026,7 +1026,14 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
                     }
 
                     if (eventType)
-                        CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->position, scn->line);
+                    {
+                        if (((LPNMHDR)lParam)->code == SCN_CHARADDED)
+                            CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->ch, scn->position);
+                        else if (((LPNMHDR)lParam)->code == SCN_MARGINCLICK)
+                            CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->position, scn->margin);
+                        else
+                            CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->position, scn->line);
+                    }
                 }
                 break;
 

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -32,6 +32,7 @@ caption text is logically set (WM_SETTEXT/GetWindowText) but not painted.
 
 
 #ifndef SCN_MODIFIED
+#define SCI_GETCHARAT 2007
 #define SCN_UPDATEUI 2007
 #define SCN_MODIFIED 2008
 #define SCN_MARGINCLICK 2010
@@ -1034,7 +1035,10 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
                     {
                         if (((LPNMHDR)lParam)->code == SCN_CHARADDED)
                         {
-                            CALL_CALLBACK(pwbobj->id, eventType, scn->ch, scn->position);
+                            LONG_PTR ch = scn->ch;
+                            if (!ch && scn->position > 0)
+                                ch = SendMessage(pwbobj->hwnd, SCI_GETCHARAT, (WPARAM)(scn->position - 1), 0);
+                            CALL_CALLBACK(pwbobj->id, eventType, ch, scn->position);
                         }
                         else if (((LPNMHDR)lParam)->code == SCN_MARGINCLICK)
                         {

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -1000,27 +1000,32 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
                 case ScintillaEdit:
                 {
                     WB_SCNOTIFICATION *scn = (WB_SCNOTIFICATION *)lParam;
+                    LONG_PTR notifyMask;
                     LPARAM eventType = 0;
+
+                    // Scintilla notifications are configured on the control's lparam in wb_create_control(..., param).
+                    // Fall back to window-level notify flags for compatibility.
+                    notifyMask = pwbobj->lparam ? pwbobj->lparam : ((pwbobj->parent->uClass == TabControl) ? pwbobj->parent->parent->lparam : pwbobj->parent->lparam);
 
                     switch (((LPNMHDR)lParam)->code)
                     {
                     case SCN_MODIFIED:
-                        if (SEND_MESSAGE && TEST_FLAG(WBC_SCN_MODIFIED))
+                        if (notifyMask & WBC_SCN_MODIFIED)
                             eventType = WBC_SCN_MODIFIED;
                         break;
 
                     case SCN_UPDATEUI:
-                        if (SEND_MESSAGE && TEST_FLAG(WBC_SCN_UPDATEUI))
+                        if (notifyMask & WBC_SCN_UPDATEUI)
                             eventType = WBC_SCN_UPDATEUI;
                         break;
 
                     case SCN_MARGINCLICK:
-                        if (SEND_MESSAGE && TEST_FLAG(WBC_SCN_MARGINCLICK))
+                        if (notifyMask & WBC_SCN_MARGINCLICK)
                             eventType = WBC_SCN_MARGINCLICK;
                         break;
 
                     case SCN_CHARADDED:
-                        if (SEND_MESSAGE && TEST_FLAG(WBC_SCN_CHARADDED))
+                        if (notifyMask & WBC_SCN_CHARADDED)
                             eventType = WBC_SCN_CHARADDED;
                         break;
                     }

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -1028,11 +1028,17 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
                     if (eventType)
                     {
                         if (((LPNMHDR)lParam)->code == SCN_CHARADDED)
+                        {
                             CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->ch, scn->position);
+                        }
                         else if (((LPNMHDR)lParam)->code == SCN_MARGINCLICK)
+                        {
                             CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->position, scn->margin);
+                        }
                         else
+                        {
                             CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->position, scn->line);
+                        }
                     }
                 }
                 break;

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -30,6 +30,41 @@ caption text is logically set (WM_SETTEXT/GetWindowText) but not painted.
 #define DEFAULT_WIN_STYLE (WS_POPUP | WS_MINIMIZEBOX | WS_VISIBLE | WS_CLIPSIBLINGS | WS_CLIPCHILDREN | WS_MAXIMIZEBOX | WS_CAPTION | WS_BORDER | WS_SYSMENU | WS_THICKFRAME)
 #define CUSTOM_MESSAGE_NAME "@WB_win32_%d_%s"
 
+
+#ifndef SCN_MODIFIED
+#define SCN_UPDATEUI 2007
+#define SCN_MODIFIED 2008
+#define SCN_MARGINCLICK 2010
+#define SCN_CHARADDED 2001
+
+typedef struct _WB_SCNOTIFICATION
+{
+	NMHDR nmhdr;
+	int position;
+	int ch;
+	int modifiers;
+	int modificationType;
+	const char *text;
+	int length;
+	int linesAdded;
+	int message;
+	WPARAM wParam;
+	LPARAM lParam;
+	int line;
+	int foldLevelNow;
+	int foldLevelPrev;
+	int margin;
+	int listType;
+	int x;
+	int y;
+	int token;
+	int annotationLinesAdded;
+	int updated;
+	int listCompletionMethod;
+	int characterSource;
+} WB_SCNOTIFICATION;
+#endif
+
 //----------------------------------------------------------------------- MACROS
 
 #define CALL_CALLBACK(id, lp1, lp2, lp3) /* Call user function */                                                                         \
@@ -961,6 +996,39 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
                         return 0;
                     }
                     break;
+
+                case ScintillaEdit:
+                {
+                    WB_SCNOTIFICATION *scn = (WB_SCNOTIFICATION *)lParam;
+                    LPARAM eventType = 0;
+
+                    switch (((LPNMHDR)lParam)->code)
+                    {
+                    case SCN_MODIFIED:
+                        if (SEND_MESSAGE && TEST_FLAG(WBC_SCN_MODIFIED))
+                            eventType = WBC_SCN_MODIFIED;
+                        break;
+
+                    case SCN_UPDATEUI:
+                        if (SEND_MESSAGE && TEST_FLAG(WBC_SCN_UPDATEUI))
+                            eventType = WBC_SCN_UPDATEUI;
+                        break;
+
+                    case SCN_MARGINCLICK:
+                        if (SEND_MESSAGE && TEST_FLAG(WBC_SCN_MARGINCLICK))
+                            eventType = WBC_SCN_MARGINCLICK;
+                        break;
+
+                    case SCN_CHARADDED:
+                        if (SEND_MESSAGE && TEST_FLAG(WBC_SCN_CHARADDED))
+                            eventType = WBC_SCN_CHARADDED;
+                        break;
+                    }
+
+                    if (eventType)
+                        CALL_CALLBACK(((LPNMHDR)lParam)->idFrom, eventType, scn->position, scn->line);
+                }
+                break;
 
                 case Calendar:
                 {

--- a/wb/wb_winsys.c
+++ b/wb/wb_winsys.c
@@ -59,6 +59,8 @@ static HCURSOR GetSysCursor(LPCTSTR pszCursor);
 static char *GetTokenExt(const char *pszBuffer, int nToken, const char *pszSep, char chGroup, BOOL fBlock, char *pszToken, int nTokLen);
 static char *GetToken(const char *pszBuffer, int nToken, char *pszToken, int nTokLen);
 
+BOOL bScintillaAvailable = FALSE;
+
 // Public to wb_* modules
 
 LPTSTR MakeWinPath(LPTSTR pszPath);
@@ -90,6 +92,9 @@ BOOL wbInit(void)
 	InitCommonControls();
 	if (!LoadLibrary(TEXT("RICHED20.DLL"))) // This is version 2.0 of the DLL
 		LoadLibrary(TEXT("RICHED32.DLL"));
+	bScintillaAvailable = (LoadLibrary(TEXT("SciLexer.dll")) != NULL);
+	if (!bScintillaAvailable)
+		wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Scintilla runtime (SciLexer.dll) not found. ScintillaEdit controls will be unavailable."));
 	icex.dwSize = sizeof(icex);
 	icex.dwICC = ICC_DATE_CLASSES; // Load date and time picker control class
 	InitCommonControlsEx(&icex);
@@ -488,6 +493,7 @@ BOOL wbIsValidClass(UINT64 uClass)
 	case TabControl:
 	case ToolBar:
 	case TreeView:
+	case ScintillaEdit:
 		return TRUE;
 	}
 	return FALSE;


### PR DESCRIPTION
### Motivation
- Improve PHP editor ergonomics by providing easy-to-use autocomplete and calltip helpers so PHP userland can trigger common IDE behaviors without raw Win32 messaging.
- Add simple visibility toggles for whitespace and EOL markers to let scripts control visual clutter programmatically.
- Provide a small, documented Phase 5 demo that shows how to trigger autocomplete from editor events for real-world validation.

### Description
- Implemented Phase 5 helper APIs in `phpwb_control.c`: `wb_scintilla_autocomplete_show`, `wb_scintilla_autocomplete_cancel`, `wb_scintilla_calltip_show`, `wb_scintilla_calltip_cancel`, `wb_scintilla_set_whitespace_view`, `wb_scintilla_set_eol_view`, and `wb_scintilla_show_php_autocomplete`, plus PHP-facing wrappers for core Scintilla operations used by the demo.
- Exported the new functions in `phpwb_export.c` and added typed arginfo entries in `phpwb_wb_arginfo.h` so the helpers are callable and type-checked from PHP.
- Updated documentation and example: `docs/manual/classes/scintillaedit.html` describes Phase 5 ergonomics and references the new APIs, and `docs/manual/examples/scintilla_basic.php` demonstrates toggling whitespace/EOL and triggering PHP autocomplete from `WBC_SCN_CHARADDED` when `$`, `:`, or `>` are typed.
- Kept runtime safety and integration consistent by using existing Scintilla constants, adding small message constants for the new helpers in headers, and reusing the control/object validation helper `wbPhpGetScintillaObj()` to ensure functions operate only on `ScintillaEdit` objects.

### Testing
- Ran `php -l docs/manual/examples/scintilla_basic.php` which reported no syntax errors.
- Verified new symbols are present across sources with a targeted search for `wb_scintilla_*` helpers which returned expected hits in `phpwb_control.c`, `phpwb_export.c`, `phpwb_wb_arginfo.h`, and the docs.
- Ran `git diff --check` to ensure there are no whitespace or formatting problems, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699d6de75d10832cbbc454aaa2514e6e)