### PR TITLE
Avoid forced RedrawWindow when updating window captions in `wb_set_text`

### DIFF
--- a/wb/wb_control.c
+++ b/wb/wb_control.c
@@ -1060,14 +1060,7 @@ BOOL wbSetText(PWBOBJ pwbo, LPCTSTR pszSourceText, int nItem, BOOL bTooltip)
 		case PopupWindow:
 		case ResizableWindow:
 		case ToolDialog:
-		{
-			BOOL bSet = SetWindowText(pwbo->hwnd, pszText);
-			if (bSet)
-			{
-				RedrawWindow(pwbo->hwnd, NULL, NULL, RDW_FRAME | RDW_INVALIDATE | RDW_UPDATENOW);
-			}
-			return bSet;
-		}
+			return SetWindowText(pwbo->hwnd, pszText);
 
 		default:
 


### PR DESCRIPTION
### Motivation
- Updating top-level window captions via `wb_set_text` previously called `RedrawWindow(..., RDW_FRAME | RDW_INVALIDATE | RDW_UPDATENOW)`, which could hide or disrupt child/frame controls after title changes.
- Remove the forced redraw to let the system handle caption painting and avoid the regressions observed when setting window titles.

### Description
- Simplified the window-class branch in `wb/wb_control.c` inside `wbSetText` to return `SetWindowText(pwbo->hwnd, pszText)` directly for `AppWindow`, `ModalDialog`, `ModelessDialog`, `PopupWindow`, `ResizableWindow`, and `ToolDialog` cases.
- Removed the manual `RedrawWindow(pwbo->hwnd, NULL, NULL, RDW_FRAME | RDW_INVALIDATE | RDW_UPDATENOW)` path that followed `SetWindowText` for those classes.
- Kept existing behavior for `StatusBar`, `Menu`, `TabControl`, and other control classes unchanged.

### Testing
- Ran `git diff -- wb/wb_control.c` to inspect the change and it showed the redraw removal; command completed successfully.
- Ran `git show --stat --oneline HEAD` to verify the commit summary and it completed successfully.
- Ran `git status --short` to verify a clean working tree and it completed successfully.
- UI/runtime verification on Windows was not executed because this environment does not provide a Windows GUI runtime to validate `wb_set_text` painting behavior at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699f029b1c84832cb47518bd701daaef)