### PR TITLE
Unify WinBinder/PHP error behavior behind winbinder.debug_level

### DIFF
--- a/phpwb_wb_lib.c
+++ b/phpwb_wb_lib.c
@@ -66,18 +66,39 @@ BOOL wbError(LPCTSTR szFunction, int nType, LPCTSTR pszFmt, ...)
 		break;
 	}
 
-	// Normal error with stack trace
-	php_error_docref(NULL, messageType, str);
-
-
-	/* if not debug mode show friendly error box (only for fatal errors)
-	if (INI_INT("winbinder.debug_level") == 0 && messageType == E_ERROR)
-	{
-		szMsg = Utf82WideChar(str, 0);
-		szTitle = Utf82WideChar("wbError", 0);
-		wbMessageBox(NULL, szMsg, szTitle, nType);
-	}
+	/*
+		winbinder.debug_level modes:
+		0 => Message box only
+		1 => PHP error only
+		2 => Both PHP error and message box
 	*/
+	switch (INI_INT("winbinder.debug_level"))
+	{
+		case 0:
+			szMsg = Utf82WideChar(str, 0);
+			szTitle = Utf82WideChar("WinBinder", 0);
+			wbMessageBox(NULL, szMsg, szTitle, nType);
+			if (szMsg)
+				efree(szMsg);
+			if (szTitle)
+				efree(szTitle);
+			break;
+
+		case 1:
+			php_error_docref(NULL, messageType, str);
+			break;
+
+		default:
+			php_error_docref(NULL, messageType, str);
+			szMsg = Utf82WideChar(str, 0);
+			szTitle = Utf82WideChar("WinBinder", 0);
+			wbMessageBox(NULL, szMsg, szTitle, nType);
+			if (szMsg)
+				efree(szMsg);
+			if (szTitle)
+				efree(szTitle);
+			break;
+	}
 	return FALSE;
 }
 

--- a/phpwb_winsys.c
+++ b/phpwb_winsys.c
@@ -1238,7 +1238,7 @@ ZEND_FUNCTION(wb_send_key)
 		uSent = SendInput(kcount*2, inputs, sizeof(INPUT));
 		RETURN_BOOL(uSent == (kcount*2));
 	} else {
-		php_error_docref(NULL, E_WARNING, "Parameter 1 should be a an long or an array of longs");
+		wbError(TEXT("wb_send_key"), MB_ICONWARNING, TEXT("Parameter 1 should be a long or an array of longs"));
 		RETURN_BOOL(FALSE);
 	}
 }


### PR DESCRIPTION
## Summary
- refactored `wbError()` to make `winbinder.debug_level` the single switch for error presentation behavior
- introduced explicit debug-level modes:
  - `0`: show WinBinder message box only
  - `1`: emit standard PHP error only
  - `2+`: emit PHP error and show WinBinder message box
- cleaned up message-box memory handling by freeing UTF conversion buffers after display
- replaced a direct `php_error_docref()` call in `wb_send_key()` with `wbError()` so this path also follows the unified behavior

## Why
Error handling was split between `wbError()` and direct PHP error APIs. This made behavior inconsistent and difficult to control globally. Routing user-facing warnings through `wbError()` and honoring `winbinder.debug_level` provides consistent, configurable output for both CLI/debug and GUI workflows.

## Changed files
- `phpwb_wb_lib.c`
- `phpwb_winsys.c`

## Notes
- No test execution was performed in this pass.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a81e3ce40c832c8b784f343f41e016)