### PR TITLE
Add split-button toolbar support with distinct callback events

### DIFF
--- a/docs/manual/classes/toolbar.html
+++ b/docs/manual/classes/toolbar.html
@@ -12,11 +12,23 @@ Classes,ToolBar
 Toolbars
 -->
 <h2>ToolBar class</h2>
-<p>A ToolBar is an horizontal bar container with buttons.</p>
+<p>A ToolBar is a horizontal bar container with buttons.</p>
+
+<h1><b>Split buttons</b></h1>
+<p>ToolBar buttons can now be configured as split buttons with independent primary and
+arrow-click behavior.</p>
+<ul>
+<li>Use <code>wb_toolbar_attach_split_menu($toolbar, $buttonId, $menu)</code> to attach a dropdown menu.</li>
+<li>Use <code>wb_toolbar_set_split_default($toolbar, $buttonId, $commandId)</code> to change the default action used by the primary click.</li>
+<li>In your callback, <code>$lparam1</code> is <code>WBC_SPLIT_PRIMARY</code> for primary clicks and
+<code>WBC_SPLIT_DROPDOWN</code> for arrow clicks.</li>
+<li>For split events, <code>$lparam2</code> contains the selected/default command id.</li>
+</ul>
+
+<p>See <a href="../examples/toolbar_split_run.php">toolbar_split_run.php</a> for a "Run" + "Run With Options" pattern.</p>
 
 <h1><b>See also</b></h1>
-<p><a href="../reference/classes_control.html">Control
-classes</a></p>
+<p><a href="../reference/classes_control.html">Control classes</a></p>
 
 <p>&nbsp;</p>
 

--- a/docs/manual/examples/toolbar_split_run.php
+++ b/docs/manual/examples/toolbar_split_run.php
@@ -1,0 +1,48 @@
+<?php
+
+include "../phpwb.php";
+
+define('ID_RUN', 1001);
+define('ID_RUN_DEFAULT', 1100);
+define('ID_RUN_SAFE', 1101);
+define('ID_RUN_VERBOSE', 1102);
+
+$win = wb_create_window(null, AppWindow, 'Split toolbar demo', WBC_CENTER, WBC_CENTER, 520, 220, 0);
+
+$menu = wb_create_menu($win, [
+    ['Run', ID_RUN_DEFAULT],
+    ['Run safely', ID_RUN_SAFE],
+    ['Run with verbose logging', ID_RUN_VERBOSE],
+]);
+
+$toolbarItems = [
+    [ID_RUN, '', 'Run', 0],
+];
+
+$toolbar = wb_create_toolbar($win, $toolbarItems, 16, 16, null);
+wb_toolbar_attach_split_menu($toolbar, ID_RUN, $menu);
+wb_toolbar_set_split_default($toolbar, ID_RUN, ID_RUN_DEFAULT);
+
+$status = wb_create_control($win, Label, '', 10, 60, 490, 90, 5000, 0, 0);
+wb_set_text($status, "Click Run for default action, or the arrow for options.");
+
+wb_set_handler($win, 'process_main');
+wb_main_loop();
+
+function process_main($window, $id, $ctrl = null, $lparam1 = null, $lparam2 = null)
+{
+    if ($id == ID_RUN) {
+        if ($lparam1 == WBC_SPLIT_PRIMARY) {
+            wb_message_box($window, "Primary click -> command {$lparam2}", "Run");
+        } elseif ($lparam1 == WBC_SPLIT_DROPDOWN) {
+            if ($lparam2 > 0) {
+                wb_toolbar_set_split_default($ctrl, ID_RUN, $lparam2);
+                wb_message_box($window, "Dropdown click -> selected {$lparam2}.\nDefault updated.", "Run With Options");
+            }
+        }
+    }
+
+    if ($id == IDCLOSE) {
+        wb_destroy_window($window);
+    }
+}

--- a/phpwb_control_toolbar.c
+++ b/phpwb_control_toolbar.c
@@ -137,7 +137,7 @@ ZEND_FUNCTION(wb_toolbar_attach_split_menu)
 		Z_PARAM_LONG(lMenu)
 	ZEND_PARSE_PARAMETERS_END();
 
-	if (!wbIsWBObj((void *)lToolbar, TRUE) || !wbIsWBObj((void *)lMenu, TRUE))
+	if (!wbIsWBObj((void *)lToolbar, TRUE))
 	{
 		RETURN_FALSE;
 	}

--- a/phpwb_control_toolbar.c
+++ b/phpwb_control_toolbar.c
@@ -126,4 +126,41 @@ ZEND_FUNCTION(wb_create_toolbar)
 	RETURN_LONG(l);
 }
 
+
+ZEND_FUNCTION(wb_toolbar_attach_split_menu)
+{
+	zend_long lToolbar, button_id, lMenu;
+
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_LONG(lToolbar)
+		Z_PARAM_LONG(button_id)
+		Z_PARAM_LONG(lMenu)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!wbIsWBObj((void *)lToolbar, TRUE) || !wbIsWBObj((void *)lMenu, TRUE))
+	{
+		RETURN_FALSE;
+	}
+
+	RETURN_BOOL(wbToolbarAttachSplitMenu((PWBOBJ)lToolbar, (int)button_id, (PWBOBJ)lMenu));
+}
+
+ZEND_FUNCTION(wb_toolbar_set_split_default)
+{
+	zend_long lToolbar, button_id, default_command;
+
+	ZEND_PARSE_PARAMETERS_START(3, 3)
+		Z_PARAM_LONG(lToolbar)
+		Z_PARAM_LONG(button_id)
+		Z_PARAM_LONG(default_command)
+	ZEND_PARSE_PARAMETERS_END();
+
+	if (!wbIsWBObj((void *)lToolbar, TRUE))
+	{
+		RETURN_FALSE;
+	}
+
+	RETURN_BOOL(wbToolbarSetSplitDefault((PWBOBJ)lToolbar, (int)button_id, (int)default_command));
+}
+
 //------------------------------------------------------------------ END OF FILE

--- a/phpwb_export.c
+++ b/phpwb_export.c
@@ -202,6 +202,8 @@ ZEND_FUNCTION(wb_set_menu_item_image);
 
 // PHPWB_CONTROL_TOOLBAR.C
 ZEND_FUNCTION(wb_create_toolbar);
+ZEND_FUNCTION(wb_toolbar_attach_split_menu);
+ZEND_FUNCTION(wb_toolbar_set_split_default);
 
 // PHPWB_CONTROL_TREEVIEW.C
 ZEND_FUNCTION(wb_create_treeview_item);
@@ -421,6 +423,8 @@ zend_function_entry winbinder_functions[] =
 
         // PHPWB_CONTROL_TOOLBAR.C
         ZEND_FE(wb_create_toolbar,arginfo_wb_create_toolbar)
+        ZEND_FE(wb_toolbar_attach_split_menu,arginfo_wb_toolbar_attach_split_menu)
+        ZEND_FE(wb_toolbar_set_split_default,arginfo_wb_toolbar_set_split_default)
 
         // PHPWB_CONTROL_TREEVIEW.C
         ZEND_FE(wb_create_treeview_item,arginfo_wb_create_treeview_item)
@@ -596,6 +600,8 @@ ZEND_MINIT_FUNCTION(winbinder)
 	WB_ZEND_CONST(LONG, "WBC_SCN_UPDATEUI", WBC_SCN_UPDATEUI)
 	WB_ZEND_CONST(LONG, "WBC_SCN_MARGINCLICK", WBC_SCN_MARGINCLICK)
 	WB_ZEND_CONST(LONG, "WBC_SCN_CHARADDED", WBC_SCN_CHARADDED)
+	WB_ZEND_CONST(LONG, "WBC_SPLIT_PRIMARY", WBC_SPLIT_PRIMARY)
+	WB_ZEND_CONST(LONG, "WBC_SPLIT_DROPDOWN", WBC_SPLIT_DROPDOWN)
 	WB_ZEND_CONST(LONG, "WBC_TASK_PROGRESS", WBC_TASK_PROGRESS)
 	WB_ZEND_CONST(LONG, "WBC_TASK_COMPLETE", WBC_TASK_COMPLETE)
 	WB_ZEND_CONST(LONG, "WBC_TASK_ERROR", WBC_TASK_ERROR)

--- a/phpwb_wb_arginfo.h
+++ b/phpwb_wb_arginfo.h
@@ -751,6 +751,18 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_MASK_EX(arginfo_wb_create_toolbar, 0, 2, MAY_BE_
 	ZEND_ARG_TYPE_MASK(0, image, MAY_BE_NULL|MAY_BE_STRING, "null")
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_toolbar_attach_split_menu, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, toolbar, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, button_id, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, menu, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_toolbar_set_split_default, 0, 3, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, toolbar, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, button_id, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, default_command, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_create_treeview_item, 0, 2, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
 	ZEND_ARG_TYPE_INFO(0, caption, IS_STRING, 0)

--- a/wb/wb.h
+++ b/wb/wb.h
@@ -265,6 +265,8 @@ enum
 #define WBC_SCN_UPDATEUI 0x00040000
 #define WBC_SCN_MARGINCLICK 0x00080000
 #define WBC_SCN_CHARADDED 0x00100000
+#define WBC_SPLIT_PRIMARY 0x00200000
+#define WBC_SPLIT_DROPDOWN 0x00400000
 
 // ListView item-changed event discriminators (callback lParam1)
 #define WBC_LV_SELECTED 0x00000001
@@ -562,6 +564,9 @@ BOOL wbSetMenuItemImage(PWBOBJ pwbo, HANDLE hImage);
 // WB_CONTROL_TOOLBAR.C
 
 PWBOBJ wbCreateToolbar(PWBOBJ pwboParent, PWBITEM pitem[], int nItems, int nBtnWidth, int nBtnHeight, HBITMAP hbm);
+BOOL wbToolbarAttachSplitMenu(PWBOBJ pwboToolbar, int nButtonId, PWBOBJ pwboMenu);
+BOOL wbToolbarSetSplitDefault(PWBOBJ pwboToolbar, int nButtonId, int nDefaultCommand);
+BOOL wbToolbarGetSplitInfo(HWND hwndToolbar, int nButtonId, HMENU *phMenu, int *pnDefaultCommand);
 
 // WB_CONTROL_TREEVIEW.C
 

--- a/wb/wb_control_toolbar.c
+++ b/wb/wb_control_toolbar.c
@@ -20,6 +20,20 @@
 static HWND CreateToolbar(HWND hwndParent, int nButtons, int nBtnWidth, int nBtnHeight, HBITMAP hbm);
 static BOOL CreateToolbarButton(HWND hwnd, int id, int nIndex, LPCTSTR pszHint);
 
+typedef struct _WBSPLITBTN
+{
+	HWND hwndToolbar;
+	int nButtonId;
+	HMENU hMenu;
+	int nDefaultCommand;
+	struct _WBSPLITBTN *pNext;
+} WBSPLITBTN, *PWBSPLITBTN;
+
+static PWBSPLITBTN g_pSplitButtons = NULL;
+
+static PWBSPLITBTN FindSplitButton(HWND hwndToolbar, int nButtonId);
+static PWBSPLITBTN FindOrCreateSplitButton(HWND hwndToolbar, int nButtonId);
+
 // External
 
 extern void SetToolBarHandle(HWND hCtrl);
@@ -89,6 +103,7 @@ static HWND CreateToolbar(HWND hwndParent, int nButtons, int nBtnWidth, int nBtn
 		return NULL;
 
 	SetToolBarHandle(hTBWnd);
+	SendMessage(hTBWnd, TB_SETEXTENDEDSTYLE, 0, TBSTYLE_EX_DRAWDDARROWS);
 
 	// Create an ImageList with transparent bitmaps
 
@@ -159,6 +174,96 @@ static BOOL CreateToolbarButton(HWND hwnd, int id, int nIndex, LPCTSTR pszHint)
 			wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Could not create separator in toolbar"));
 	}
 	return bRet;
+}
+
+
+
+BOOL wbToolbarAttachSplitMenu(PWBOBJ pwboToolbar, int nButtonId, PWBOBJ pwboMenu)
+{
+	TBBUTTONINFO tbbi = {0};
+	PWBSPLITBTN pSplit;
+
+	if (!pwboToolbar || pwboToolbar->uClass != ToolBar || !IsWindow(pwboToolbar->hwnd))
+		return FALSE;
+
+	if (!pwboMenu || pwboMenu->uClass != Menu || !pwboMenu->hwnd || !IsMenu((HMENU)pwboMenu->hwnd))
+		return FALSE;
+
+	pSplit = FindOrCreateSplitButton(pwboToolbar->hwnd, nButtonId);
+	if (!pSplit)
+		return FALSE;
+
+	pSplit->hMenu = (HMENU)pwboMenu->hwnd;
+	if (pSplit->nDefaultCommand == 0)
+		pSplit->nDefaultCommand = nButtonId;
+
+	tbbi.cbSize = sizeof(TBBUTTONINFO);
+	tbbi.dwMask = TBIF_STYLE;
+	tbbi.fsStyle = TBSTYLE_BUTTON | TBSTYLE_DROPDOWN;
+
+	if (!SendMessage(pwboToolbar->hwnd, TB_SETBUTTONINFO, nButtonId, (LPARAM)&tbbi))
+		return FALSE;
+
+	return TRUE;
+}
+
+BOOL wbToolbarSetSplitDefault(PWBOBJ pwboToolbar, int nButtonId, int nDefaultCommand)
+{
+	PWBSPLITBTN pSplit;
+
+	if (!pwboToolbar || pwboToolbar->uClass != ToolBar || !IsWindow(pwboToolbar->hwnd))
+		return FALSE;
+
+	pSplit = FindSplitButton(pwboToolbar->hwnd, nButtonId);
+	if (!pSplit)
+		return FALSE;
+
+	pSplit->nDefaultCommand = nDefaultCommand;
+	return TRUE;
+}
+
+BOOL wbToolbarGetSplitInfo(HWND hwndToolbar, int nButtonId, HMENU *phMenu, int *pnDefaultCommand)
+{
+	PWBSPLITBTN pSplit = FindSplitButton(hwndToolbar, nButtonId);
+	if (!pSplit || !pSplit->hMenu)
+		return FALSE;
+
+	if (phMenu)
+		*phMenu = pSplit->hMenu;
+	if (pnDefaultCommand)
+		*pnDefaultCommand = pSplit->nDefaultCommand;
+	return TRUE;
+}
+
+static PWBSPLITBTN FindSplitButton(HWND hwndToolbar, int nButtonId)
+{
+	PWBSPLITBTN pItem = g_pSplitButtons;
+	while (pItem)
+	{
+		if (pItem->hwndToolbar == hwndToolbar && pItem->nButtonId == nButtonId)
+			return pItem;
+		pItem = pItem->pNext;
+	}
+	return NULL;
+}
+
+static PWBSPLITBTN FindOrCreateSplitButton(HWND hwndToolbar, int nButtonId)
+{
+	PWBSPLITBTN pItem = FindSplitButton(hwndToolbar, nButtonId);
+	if (pItem)
+		return pItem;
+
+	pItem = wbMalloc(sizeof(WBSPLITBTN));
+	if (!pItem)
+		return NULL;
+
+	pItem->hwndToolbar = hwndToolbar;
+	pItem->nButtonId = nButtonId;
+	pItem->hMenu = NULL;
+	pItem->nDefaultCommand = nButtonId;
+	pItem->pNext = g_pSplitButtons;
+	g_pSplitButtons = pItem;
+	return pItem;
 }
 
 //------------------------------------------------------------------ END OF FILE

--- a/wb/wb_control_toolbar.c
+++ b/wb/wb_control_toolbar.c
@@ -183,10 +183,16 @@ BOOL wbToolbarAttachSplitMenu(PWBOBJ pwboToolbar, int nButtonId, PWBOBJ pwboMenu
 	TBBUTTONINFO tbbi = {0};
 	PWBSPLITBTN pSplit;
 
-	if (!pwboToolbar || pwboToolbar->uClass != ToolBar || !IsWindow(pwboToolbar->hwnd))
+	if (!pwboToolbar || IsBadReadPtr(pwboToolbar, sizeof(WBOBJ)))
 		return FALSE;
 
-	if (!pwboMenu || pwboMenu->uClass != Menu || !pwboMenu->hwnd || !IsMenu((HMENU)pwboMenu->hwnd))
+	if (pwboToolbar->uClass != ToolBar || !pwboToolbar->hwnd || !IsWindow(pwboToolbar->hwnd))
+		return FALSE;
+
+	if (!pwboMenu || IsBadReadPtr(pwboMenu, sizeof(WBOBJ)))
+		return FALSE;
+
+	if (pwboMenu->uClass != Menu || !pwboMenu->hwnd || !IsMenu((HMENU)pwboMenu->hwnd))
 		return FALSE;
 
 	pSplit = FindOrCreateSplitButton(pwboToolbar->hwnd, nButtonId);

--- a/wb/wb_generic.c
+++ b/wb/wb_generic.c
@@ -51,18 +51,18 @@ BOOL wbIsWBObj(void *pwbo, BOOL bShowErrors)
 
 	// Does it have a valid handle?
 	//printf("wbIsWBObj 4\n");
-    HWND hwnd = ((PWBOBJ)pwbo)->hwnd;
-    if (!hwnd || !IsWindow(hwnd)) {
-        if (bShowErrors)
-            wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Invalid WinBinder object handle"));
-        return FALSE;
-    }
+	if (!((PWBOBJ)pwbo)->hwnd)
+	{
+		if (bShowErrors)
+			wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Invalid WinBinder object handle"));
+		return FALSE;
+	}
 
-    //printf("wbIsWBObj 5\n");
+	//printf("wbIsWBObj 5\n");
 	if (IsMenu((HMENU)((PWBOBJ)pwbo)->hwnd))
 		return TRUE;
 
-    //printf("wbIsWBObj 6\n");
+	//printf("wbIsWBObj 6\n");
 	if (IsWindow((HWND)((PWBOBJ)pwbo)->hwnd))
 		return TRUE;
 

--- a/wb/wb_generic.c
+++ b/wb/wb_generic.c
@@ -51,18 +51,18 @@ BOOL wbIsWBObj(void *pwbo, BOOL bShowErrors)
 
 	// Does it have a valid handle?
 	//printf("wbIsWBObj 4\n");
-	if (!((PWBOBJ)pwbo)->hwnd)
-	{
-		if (bShowErrors)
-			wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Invalid WinBinder object handle"));
-		return FALSE;
-	}
+    HWND hwnd = ((PWBOBJ)pwbo)->hwnd;
+    if (!hwnd || !IsWindow(hwnd)) {
+        if (bShowErrors)
+            wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Invalid WinBinder object handle"));
+        return FALSE;
+    }
 
-	//printf("wbIsWBObj 5\n");
+    //printf("wbIsWBObj 5\n");
 	if (IsMenu((HMENU)((PWBOBJ)pwbo)->hwnd))
 		return TRUE;
 
-	//printf("wbIsWBObj 6\n");
+    //printf("wbIsWBObj 6\n");
 	if (IsWindow((HWND)((PWBOBJ)pwbo)->hwnd))
 		return TRUE;
 

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -1438,9 +1438,13 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
                         HMENU hSplitMenu = NULL;
                         int nDefaultCommand = LOWORD(wParam);
                         if (wbToolbarGetSplitInfo(pwbobj->hwnd, LOWORD(wParam), &hSplitMenu, &nDefaultCommand))
+                        {
                             CALL_CALLBACK(LOWORD(wParam), WBC_SPLIT_PRIMARY, nDefaultCommand, HIWORD(wParam));
+                        }
                         else
+                        {
                             CALL_CALLBACK(LOWORD(wParam), 0, HIWORD(wParam), 0);
+                        }
                     }
                     else
                     {

--- a/wb/wb_window.c
+++ b/wb/wb_window.c
@@ -921,11 +921,54 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
 
             if (!_wcsicmp(szClass, TOOLBARCLASSNAME))
             { // Toolbar
-
                 if (!hTBWnd)
                     hTBWnd = ((LPNMHDR)lParam)->hwndFrom;
+
+                if (((LPNMHDR)lParam)->code == TBN_DROPDOWN)
+                {
+                    LPNMTOOLBAR pnm = (LPNMTOOLBAR)lParam;
+                    PWBOBJ pToolbarObj = wbGetWBObj(hCtrl);
+                    HMENU hMenu = NULL;
+                    int nDefaultCommand = pnm->iItem;
+
+                    if (wbToolbarGetSplitInfo(hCtrl, pnm->iItem, &hMenu, &nDefaultCommand) && hMenu)
+                    {
+                        RECT rcBtn;
+                        TPMPARAMS tpm = {0};
+                        int nCommand = 0;
+
+                        SendMessage(hCtrl, TB_GETRECT, pnm->iItem, (LPARAM)&rcBtn);
+                        MapWindowPoints(hCtrl, NULL, (LPPOINT)&rcBtn, 2);
+
+                        tpm.cbSize = sizeof(tpm);
+                        tpm.rcExclude = rcBtn;
+
+                        nCommand = TrackPopupMenuEx(hMenu,
+                                                    TPM_RETURNCMD | TPM_LEFTALIGN | TPM_TOPALIGN | TPM_LEFTBUTTON,
+                                                    rcBtn.left,
+                                                    rcBtn.bottom,
+                                                    hwnd,
+                                                    &tpm);
+
+                        if (pToolbarObj && pToolbarObj->parent && pToolbarObj->parent->pszCallBackFn && *pToolbarObj->parent->pszCallBackFn)
+                        {
+                            wbCallUserFunction(pToolbarObj->parent->pszCallBackFn,
+                                               pToolbarObj->parent->pszCallBackObj,
+                                               pToolbarObj->parent,
+                                               pToolbarObj,
+                                               pnm->iItem,
+                                               WBC_SPLIT_DROPDOWN,
+                                               nCommand,
+                                               nDefaultCommand);
+                        }
+
+                        return TBDDRET_DEFAULT;
+                    }
+                }
+
                 break;
-            }  else if (!_wcsicmp(szClass, TOOLTIPS_CLASS))  { // Tooltip
+            }
+            else if (!_wcsicmp(szClass, TOOLTIPS_CLASS))  { // Tooltip
 
                 if (((LPNMHDR)lParam)->code == TTN_NEEDTEXT)
                 {
@@ -1390,7 +1433,19 @@ static LRESULT CALLBACK DefaultWBProc(HWND hwnd, UINT msg, WPARAM wParam, LPARAM
 
                 if (HIWORD(wParam) == BN_CLICKED)
                 {
-                    CALL_CALLBACK(LOWORD(wParam), 0, HIWORD(wParam), 0);
+                    if (pwbobj->uClass == ToolBar)
+                    {
+                        HMENU hSplitMenu = NULL;
+                        int nDefaultCommand = LOWORD(wParam);
+                        if (wbToolbarGetSplitInfo(pwbobj->hwnd, LOWORD(wParam), &hSplitMenu, &nDefaultCommand))
+                            CALL_CALLBACK(LOWORD(wParam), WBC_SPLIT_PRIMARY, nDefaultCommand, HIWORD(wParam));
+                        else
+                            CALL_CALLBACK(LOWORD(wParam), 0, HIWORD(wParam), 0);
+                    }
+                    else
+                    {
+                        CALL_CALLBACK(LOWORD(wParam), 0, HIWORD(wParam), 0);
+                    }
                 }
                 else if (HIWORD(wParam) == BN_SETFOCUS)
                 {


### PR DESCRIPTION
### Motivation
- Provide split-button UX for toolbar buttons so a primary click can run a default action while the arrow shows a dropdown of alternatives. 
- Route split-button interactions through the existing callback flow so callers can react to primary vs dropdown clicks with distinct event constants. 
- Allow the default action to be updated at runtime so examples like “Run” + “Run With Options” can be implemented easily.

### Description
- Added two new notification flags `WBC_SPLIT_PRIMARY` and `WBC_SPLIT_DROPDOWN` in `wb/wb.h` and exported them to PHP. 
- Extended toolbar implementation (`wb/wb_control_toolbar.c`) to enable dropdown arrows (`TB_SETEXTENDEDSTYLE` / `TBSTYLE_EX_DRAWDDARROWS`), store per-button split metadata (`WBSPLITBTN`), and provide C APIs `wbToolbarAttachSplitMenu`, `wbToolbarSetSplitDefault`, and `wbToolbarGetSplitInfo`. 
- Hooked into message handling in `wb/wb_window.c` to handle `TBN_DROPDOWN` (tracks the popup menu with `TrackPopupMenuEx` and emits `WBC_SPLIT_DROPDOWN`) and to dispatch primary-clicks on split buttons as `WBC_SPLIT_PRIMARY`. 
- Added PHP bindings `wb_toolbar_attach_split_menu($toolbar, $buttonId, $menu)` and `wb_toolbar_set_split_default($toolbar, $buttonId, $defaultCommand)`, registered them in `phpwb_export.c`, and added arginfo in `phpwb_wb_arginfo.h`. 
- Documentation updated (`docs/manual/classes/toolbar.html`) and a runnable example added at `docs/manual/examples/toolbar_split_run.php` demonstrating a "Run" + "Run With Options" pattern and dynamic default-action switching.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues, which returned no problems. (success)
- Linted the example with `php -l docs/manual/examples/toolbar_split_run.php` which reported "No syntax errors detected". (success)

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaaeca8f38832c8045edebfc577e7a)