### PR TITLE
Anchor tooltip balloons and add optional immediate display in wb_attach_tooltip

### DIFF
--- a/docs/manual/examples/validation_tooltip_demo.php
+++ b/docs/manual/examples/validation_tooltip_demo.php
@@ -6,8 +6,9 @@ $input = wb_create_control($win, EditBox, "", 90, 16, 300, 24, 1001);
 $ok = wb_create_control($win, PushButton, "Validate", 90, 56, 90, 28, 1002);
 $close = wb_create_control($win, PushButton, "Close", 190, 56, 90, 28, 1003);
 
-wb_attach_tooltip($input, "Enter a valid e-mail address.");
-wb_attach_tooltip($ok, "Validates and shows contextual balloon hints.");
+wb_attach_tooltip($input, "Enter a valid e-mail address.", true);
+wb_attach_tooltip($ok, "Validates and shows contextual balloon hints.
+Click to validate the field now.");
 wb_set_handler($win, "process_main");
 wb_main_loop();
 
@@ -16,6 +17,10 @@ function process_main($window, $id, $ctrl)
     global $input;
 
     switch ($id) {
+        case 1001:
+            wb_attach_tooltip($input, "Use name@example.com format.", true);
+            return;
+
         case 1002:
             $email = trim(wb_get_text($input));
             if ($email === "") {

--- a/docs/manual/functions/wb_attach_tooltip.html
+++ b/docs/manual/functions/wb_attach_tooltip.html
@@ -5,8 +5,9 @@
 </head>
 <body>
 <h2>wb_attach_tooltip</h2>
-<p>bool <b>wb_attach_tooltip</b> (int wbobject, string text)</p>
-<p>Attaches or updates tooltip text for any control or window. Pass <code>NULL</code> or an empty string to keep an empty tooltip registered for later balloon usage.</p>
+<p>bool <b>wb_attach_tooltip</b> (int wbobject, string text [, bool show_now = false])</p>
+<p>Attaches or updates tooltip text for any control or window. Pass <code>NULL</code> or an empty string to keep an empty tooltip registered for later balloon usage.<br>
+Optional <code>show_now</code> keeps backward-compatible hover behavior by default (<code>false</code>). When set to <code>true</code> and text is non-empty, a balloon is shown immediately and anchored to the target control.</p>
 <h1><b>See also</b></h1>
 <p><a href="wb_remove_tooltip.html"><b>wb_remove_tooltip</b></a><br><a href="wb_show_tooltip_balloon.html"><b>wb_show_tooltip_balloon</b></a><br><a href="wb_hide_tooltip.html"><b>wb_hide_tooltip</b></a><br><a href="wb_set_text.html"><b>wb_set_text</b></a><br><a href="../reference/functions_category.html#control">Control functions</a><br><a href="../reference/functions_category.html#window">Window functions</a></p>
 </body>

--- a/docs/manual/functions/wb_show_tooltip_balloon.html
+++ b/docs/manual/functions/wb_show_tooltip_balloon.html
@@ -7,7 +7,7 @@
 <h2>wb_show_tooltip_balloon</h2>
 <p>bool <b>wb_show_tooltip_balloon</b> (int wbobject, string text [, mixed severity = "info" [, string title = NULL]])</p>
 <p>Shows a contextual balloon tooltip near <i>wbobject</i>. Severity accepts <code>"info"</code>, <code>"warn"</code>, <code>"error"</code> (or constants <code>WBT_SEVERITY_INFO</code>, <code>WBT_SEVERITY_WARN</code>, <code>WBT_SEVERITY_ERROR</code>).</p>
-<p>This is useful for validation feedback and inline hints.</p>
+<p>This is useful for validation feedback and inline hints. Balloons are explicitly anchored to the control bounds and shown in tracking mode, so they appear immediately at a predictable location (for example after validation). For hover-only hints, continue using <a href="wb_attach_tooltip.html"><b>wb_attach_tooltip</b></a>; for immediate attach + display, use <code>wb_attach_tooltip($ctrl, $text, true)</code>.</p>
 <h1><b>See also</b></h1>
 <p><a href="wb_hide_tooltip.html"><b>wb_hide_tooltip</b></a><br><a href="wb_attach_tooltip.html"><b>wb_attach_tooltip</b></a><br><a href="../examples/validation_tooltip_demo.php">validation_tooltip_demo.php</a><br><a href="../reference/functions_category.html#control">Control functions</a><br><a href="../reference/functions_category.html#window">Window functions</a></p>
 </body>

--- a/phpwb_control.c
+++ b/phpwb_control.c
@@ -1332,12 +1332,16 @@ ZEND_FUNCTION(wb_attach_tooltip)
 {
 	zend_long pwbo;
 	zval *ztext;
+	zend_bool show_now = 0;
 	char *text = NULL;
 	TCHAR *wcsText = NULL;
+	BOOL ret;
 
-	ZEND_PARSE_PARAMETERS_START(2, 2)
+	ZEND_PARSE_PARAMETERS_START(2, 3)
 		Z_PARAM_LONG(pwbo)
 		Z_PARAM_ZVAL_OR_NULL(ztext)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(show_now)
 	ZEND_PARSE_PARAMETERS_END();
 
 	if (!wbIsWBObj((void *)pwbo, TRUE))
@@ -1351,7 +1355,18 @@ ZEND_FUNCTION(wb_attach_tooltip)
 		wcsText = Utf82WideChar(text, Z_STRLEN_P(ztext));
 	}
 
-	RETURN_BOOL(wbAttachToolTip((PWBOBJ)pwbo, wcsText));
+	ret = wbAttachToolTip((PWBOBJ)pwbo, wcsText);
+	if (!ret)
+	{
+		RETURN_BOOL(FALSE);
+	}
+
+	if (show_now && wcsText && *wcsText)
+	{
+		wbShowToolTipBalloon((PWBOBJ)pwbo, wcsText, NULL, 0);
+	}
+
+	RETURN_BOOL(ret);
 }
 
 ZEND_FUNCTION(wb_remove_tooltip)

--- a/wb/wb_control.c
+++ b/wb/wb_control.c
@@ -1016,6 +1016,9 @@ BOOL wbShowToolTipBalloon(PWBOBJ pwbo, LPCTSTR pszText, LPCTSTR pszTitle, int nS
 {
 	HWND hwndTT;
 	TOOLINFO ti;
+	RECT rc;
+	LONG x;
+	LONG y;
 	DWORD dwIcon = TTI_NONE;
 
 	if (!wbIsWBObj(pwbo, TRUE))
@@ -1029,16 +1032,22 @@ BOOL wbShowToolTipBalloon(PWBOBJ pwbo, LPCTSTR pszText, LPCTSTR pszTitle, int nS
 
 	hwndTT = (HWND)M_ToolTipWnd;
 
+	memset(&ti, 0, sizeof(TOOLINFO));
 	ti.cbSize = sizeof(TOOLINFO);
-	ti.uFlags = TTF_SUBCLASS;
+	ti.uFlags = TTF_TRACK | TTF_SUBCLASS;
 	ti.hwnd = pwbo->hwnd;
 	ti.uId = 0;
 	ti.hinst = NULL;
 	ti.lpszText = (LPTSTR)(pszText ? pszText : TEXT(""));
 	GetClientRect(pwbo->hwnd, &ti.rect);
+	GetWindowRect(pwbo->hwnd, &rc);
+
+	x = rc.left + ((rc.right - rc.left) / 2);
+	y = rc.bottom;
 
 	SendMessage(hwndTT, TTM_SETMAXTIPWIDTH, 0, 640);
 	SendMessage(hwndTT, TTM_SETTITLE, (WPARAM)TTI_NONE, (LPARAM)TEXT(""));
+	SendMessage(hwndTT, TTM_SETTOOLINFO, 0, (LPARAM)&ti);
 	SendMessage(hwndTT, TTM_UPDATETIPTEXT, 0, (LPARAM)&ti);
 
 	switch (nSeverity)
@@ -1060,6 +1069,8 @@ BOOL wbShowToolTipBalloon(PWBOBJ pwbo, LPCTSTR pszText, LPCTSTR pszTitle, int nS
 		SendMessage(hwndTT, TTM_SETTITLE, (WPARAM)dwIcon, (LPARAM)TEXT("Validation"));
 
 	SendMessage(hwndTT, TTM_ACTIVATE, TRUE, 0);
+	SendMessage(hwndTT, TTM_TRACKPOSITION, 0, (LPARAM)MAKELPARAM(x, y));
+	SendMessage(hwndTT, TTM_TRACKACTIVATE, TRUE, (LPARAM)&ti);
 	SendMessage(hwndTT, TTM_POPUP, 0, 0);
 
 	return TRUE;
@@ -1068,6 +1079,7 @@ BOOL wbShowToolTipBalloon(PWBOBJ pwbo, LPCTSTR pszText, LPCTSTR pszTitle, int nS
 BOOL wbHideToolTip(PWBOBJ pwbo)
 {
 	HWND hwndTT;
+	TOOLINFO ti;
 
 	if (!wbIsWBObj(pwbo, TRUE))
 		return FALSE;
@@ -1076,6 +1088,13 @@ BOOL wbHideToolTip(PWBOBJ pwbo)
 	if (!hwndTT || !IsWindow(hwndTT))
 		return TRUE;
 
+	memset(&ti, 0, sizeof(TOOLINFO));
+	ti.cbSize = sizeof(TOOLINFO);
+	ti.uFlags = TTF_TRACK | TTF_SUBCLASS;
+	ti.hwnd = pwbo->hwnd;
+	ti.uId = 0;
+
+	SendMessage(hwndTT, TTM_TRACKACTIVATE, FALSE, (LPARAM)&ti);
 	SendMessage(hwndTT, TTM_POP, 0, 0);
 
 	return TRUE;


### PR DESCRIPTION
### Motivation
- Ensure balloon tooltips appear at a predictable position anchored to the target control (useful for validation / immediate feedback) instead of relying on default popup placement.  
- Make the hide path consistent with tracking-mode tooltips.  
- Provide an opt-in PHP API to attach-and-show a tooltip immediately while keeping existing hover-only behavior unchanged.  
- Update docs and example to demonstrate the immediate/anchored behavior.

### Description
- Change `wbShowToolTipBalloon` in `wb/wb_control.c` to obtain control screen coordinates with `GetWindowRect()`, initialize `TOOLINFO` in tracking mode (`TTF_TRACK | TTF_SUBCLASS`), set the tool info (`TTM_SETTOOLINFO`), position with `TTM_TRACKPOSITION`, and activate via `TTM_TRACKACTIVATE` while retaining `TTM_POPUP` for compatibility.  
- Update `wbHideToolTip` in `wb/wb_control.c` to deactivate tracking tooltips using `TTM_TRACKACTIVATE` with `FALSE` and keep `TTM_POP` as cleanup.  
- Extend the PHP binding `ZEND_FUNCTION(wb_attach_tooltip)` in `phpwb_control.c` to accept an optional `show_now` boolean (3rd param); keep the default hover-only behavior when omitted/false, and when `show_now` is `true` and text is present, call `wbShowToolTipBalloon(... )` after attach to display immediately.  
- Update documentation pages `docs/manual/functions/wb_attach_tooltip.html` and `docs/manual/functions/wb_show_tooltip_balloon.html` to describe the optional immediate mode and anchored tracking behavior.  
- Update `docs/manual/examples/validation_tooltip_demo.php` to demonstrate immediate attach/display and add a focus-triggered hint example.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues; the check passed.  
- Ran PHP lint on the updated example with `php -l docs/manual/examples/validation_tooltip_demo.php`; the file has no syntax errors.  
- No runtime GUI integration tests were executed in this patch; behavior relies on Windows tooltip APIs exercised at runtime.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69aaf406cf24832cb0d8e1a1ed8ed06c)