### PR TITLE
Add VLCPlayer control with libvlc integration, PHP bindings and demo

### DIFF
--- a/docs/manual/examples/vlc_player_demo.php
+++ b/docs/manual/examples/vlc_player_demo.php
@@ -1,0 +1,181 @@
+<?php
+
+/**
+ * VLCPlayer full demo for WinBinder.
+ *
+ * Requirements:
+ * - VLC runtime installed and libvlc.dll available in PATH (or next to php.exe).
+ * - Extension build that includes VLCPlayer + wb_vlc_* APIs.
+ */
+
+define('ID_VLC', 1001);
+define('ID_OPEN', 1002);
+define('ID_PLAY', 1003);
+define('ID_PAUSE', 1004);
+define('ID_STOP', 1005);
+define('ID_SEEK', 1006);
+define('ID_VOLUME', 1007);
+define('ID_STATUS', 1008);
+define('ID_TIMER', 1009);
+
+define('SEEK_MAX', 1000);
+
+$window = wb_create_window(0, AppWindow, 'VLCPlayer full demo', WBC_CENTER, WBC_CENTER, 920, 640, WBC_NOTIFY, 0);
+
+$vlc = wb_create_control($window, VLCPlayer, '', 12, 12, 896, 460, ID_VLC, WBC_BORDER);
+
+$openBtn  = wb_create_control($window, PushButton, 'Open…', 12, 486, 100, 30, ID_OPEN);
+$playBtn  = wb_create_control($window, PushButton, 'Play', 118, 486, 80, 30, ID_PLAY);
+$pauseBtn = wb_create_control($window, PushButton, 'Pause', 204, 486, 80, 30, ID_PAUSE);
+$stopBtn  = wb_create_control($window, PushButton, 'Stop', 290, 486, 80, 30, ID_STOP);
+
+$seek = wb_create_control($window, Slider, '', 12, 526, 700, 30, ID_SEEK, WBC_LINES);
+$volume = wb_create_control($window, Slider, '', 720, 526, 188, 30, ID_VOLUME, WBC_LINES);
+
+$status = wb_create_control($window, Label, 'Ready. Click Open… to choose a media file.', 12, 566, 896, 58, ID_STATUS, WBC_BORDER | WBC_MULTILINE);
+
+wb_set_range($seek, 0, SEEK_MAX);
+wb_set_value($seek, 0);
+
+wb_set_range($volume, 0, 200);
+wb_set_value($volume, 100);
+wb_vlc_set_volume($vlc, 100);
+
+$GLOBALS['app'] = [
+    'vlc' => $vlc,
+    'seek' => $seek,
+    'volume' => $volume,
+    'status' => $status,
+    'draggingSeek' => false,
+    'mediaPath' => '',
+];
+
+wb_create_timer($window, ID_TIMER, 250);
+wb_set_handler($window, 'process_main');
+wb_main_loop();
+
+function process_main($window, $id, $ctrl = 0, $param1 = 0, $param2 = 0, $param3 = 0)
+{
+    if ($id === IDCLOSE || $id === IDCANCEL) {
+        wb_destroy_window($window);
+        return;
+    }
+
+    switch ($id) {
+        case ID_OPEN:
+            open_media_file($window);
+            break;
+
+        case ID_PLAY:
+            if (!wb_vlc_play($GLOBALS['app']['vlc'])) {
+                set_status("Play failed. Did you load media and install VLC runtime (libvlc.dll)?");
+            }
+            break;
+
+        case ID_PAUSE:
+            wb_vlc_pause($GLOBALS['app']['vlc']);
+            break;
+
+        case ID_STOP:
+            wb_vlc_stop($GLOBALS['app']['vlc']);
+            wb_set_value($GLOBALS['app']['seek'], 0);
+            break;
+
+        case ID_SEEK:
+            on_seek_changed();
+            break;
+
+        case ID_VOLUME:
+            $volume = wb_get_value($GLOBALS['app']['volume']);
+            wb_vlc_set_volume($GLOBALS['app']['vlc'], $volume);
+            set_status('Volume: ' . $volume . '%');
+            break;
+
+        case ID_TIMER:
+            refresh_playback_ui();
+            break;
+    }
+}
+
+function open_media_file($window)
+{
+    $filter = [
+        'Media files (*.mp4;*.mkv;*.avi;*.mov;*.mp3;*.flac;*.wav;*.m4a;*.ogg)' => '*.mp4;*.mkv;*.avi;*.mov;*.mp3;*.flac;*.wav;*.m4a;*.ogg',
+        'All files (*.*)' => '*.*',
+    ];
+
+    $file = wb_sys_dlg_open($window, 'Open media file', $filter, '', 0);
+    if (!$file || !is_string($file)) {
+        return;
+    }
+
+    $ok = wb_vlc_set_media($GLOBALS['app']['vlc'], $file, true);
+    if (!$ok) {
+        set_status("Could not load media:\n$file\nCheck libvlc.dll availability and path.");
+        return;
+    }
+
+    $GLOBALS['app']['mediaPath'] = $file;
+    wb_set_value($GLOBALS['app']['seek'], 0);
+    set_status("Loaded and playing:\n$file");
+}
+
+function on_seek_changed()
+{
+    $lengthMs = wb_vlc_get_length($GLOBALS['app']['vlc']);
+    if ($lengthMs <= 0) {
+        return;
+    }
+
+    $raw = wb_get_value($GLOBALS['app']['seek']);
+    $targetMs = (int)round(($raw / SEEK_MAX) * $lengthMs);
+    wb_vlc_seek($GLOBALS['app']['vlc'], $targetMs);
+}
+
+function refresh_playback_ui()
+{
+    $vlc = $GLOBALS['app']['vlc'];
+    $lengthMs = wb_vlc_get_length($vlc);
+    $timeMs = wb_vlc_get_time($vlc);
+    $isPlaying = wb_vlc_is_playing($vlc);
+
+    if ($lengthMs > 0 && $timeMs >= 0) {
+        $slider = (int)round(($timeMs / max(1, $lengthMs)) * SEEK_MAX);
+        wb_set_value($GLOBALS['app']['seek'], max(0, min(SEEK_MAX, $slider)));
+    }
+
+    $state = $isPlaying ? 'Playing' : 'Paused/Stopped';
+    $name = $GLOBALS['app']['mediaPath'] !== '' ? basename($GLOBALS['app']['mediaPath']) : 'No media';
+
+    set_status(sprintf(
+        "%s\n%s | %s / %s",
+        $name,
+        $state,
+        format_ms($timeMs),
+        format_ms($lengthMs)
+    ));
+}
+
+function format_ms($ms)
+{
+    if (!is_int($ms) && !is_float($ms)) {
+        return '00:00';
+    }
+    if ($ms < 0) {
+        return '00:00';
+    }
+    $total = (int)floor($ms / 1000);
+    $h = (int)floor($total / 3600);
+    $m = (int)floor(($total % 3600) / 60);
+    $s = $total % 60;
+
+    if ($h > 0) {
+        return sprintf('%d:%02d:%02d', $h, $m, $s);
+    }
+    return sprintf('%02d:%02d', $m, $s);
+}
+
+function set_status($text)
+{
+    wb_set_text($GLOBALS['app']['status'], $text);
+}

--- a/phpwb_control.c
+++ b/phpwb_control.c
@@ -2601,5 +2601,34 @@ ZEND_FUNCTION(wb_scintilla_show_php_autocomplete)
 	RETURN_BOOL(TRUE);
 }
 
+ZEND_FUNCTION(wb_vlc_set_media)
+{
+	zend_long pwbo;
+	char *path = NULL;
+	size_t path_len = 0;
+	zend_bool autoplay = 0;
+	TCHAR *wcsPath;
+	ZEND_PARSE_PARAMETERS_START(2, 3)
+		Z_PARAM_LONG(pwbo)
+		Z_PARAM_STRING(path, path_len)
+		Z_PARAM_OPTIONAL
+		Z_PARAM_BOOL(autoplay)
+	ZEND_PARSE_PARAMETERS_END();
+	wcsPath = Utf82WideChar(path, path_len);
+	RETURN_BOOL(wbVlcLoad((PWBOBJ)pwbo, wcsPath, autoplay ? TRUE : FALSE));
+}
+
+ZEND_FUNCTION(wb_vlc_play) { zend_long pwbo; ZEND_PARSE_PARAMETERS_START(1,1) Z_PARAM_LONG(pwbo) ZEND_PARSE_PARAMETERS_END(); RETURN_BOOL(wbVlcPlay((PWBOBJ)pwbo)); }
+ZEND_FUNCTION(wb_vlc_pause) { zend_long pwbo; ZEND_PARSE_PARAMETERS_START(1,1) Z_PARAM_LONG(pwbo) ZEND_PARSE_PARAMETERS_END(); RETURN_BOOL(wbVlcPause((PWBOBJ)pwbo)); }
+ZEND_FUNCTION(wb_vlc_stop) { zend_long pwbo; ZEND_PARSE_PARAMETERS_START(1,1) Z_PARAM_LONG(pwbo) ZEND_PARSE_PARAMETERS_END(); RETURN_BOOL(wbVlcStop((PWBOBJ)pwbo)); }
+ZEND_FUNCTION(wb_vlc_seek) { zend_long pwbo, ms; ZEND_PARSE_PARAMETERS_START(2,2) Z_PARAM_LONG(pwbo) Z_PARAM_LONG(ms) ZEND_PARSE_PARAMETERS_END(); RETURN_BOOL(wbVlcSeek((PWBOBJ)pwbo, (LONG_PTR)ms)); }
+ZEND_FUNCTION(wb_vlc_get_time) { zend_long pwbo; ZEND_PARSE_PARAMETERS_START(1,1) Z_PARAM_LONG(pwbo) ZEND_PARSE_PARAMETERS_END(); RETURN_LONG(wbVlcGetTime((PWBOBJ)pwbo)); }
+ZEND_FUNCTION(wb_vlc_get_length) { zend_long pwbo; ZEND_PARSE_PARAMETERS_START(1,1) Z_PARAM_LONG(pwbo) ZEND_PARSE_PARAMETERS_END(); RETURN_LONG(wbVlcGetLength((PWBOBJ)pwbo)); }
+ZEND_FUNCTION(wb_vlc_set_position) { zend_long pwbo; double pos; ZEND_PARSE_PARAMETERS_START(2,2) Z_PARAM_LONG(pwbo) Z_PARAM_DOUBLE(pos) ZEND_PARSE_PARAMETERS_END(); RETURN_BOOL(wbVlcSetPosition((PWBOBJ)pwbo, pos)); }
+ZEND_FUNCTION(wb_vlc_get_position) { zend_long pwbo; ZEND_PARSE_PARAMETERS_START(1,1) Z_PARAM_LONG(pwbo) ZEND_PARSE_PARAMETERS_END(); RETURN_DOUBLE(wbVlcGetPosition((PWBOBJ)pwbo)); }
+ZEND_FUNCTION(wb_vlc_set_volume) { zend_long pwbo, volume; ZEND_PARSE_PARAMETERS_START(2,2) Z_PARAM_LONG(pwbo) Z_PARAM_LONG(volume) ZEND_PARSE_PARAMETERS_END(); RETURN_BOOL(wbVlcSetVolume((PWBOBJ)pwbo, (int)volume)); }
+ZEND_FUNCTION(wb_vlc_get_volume) { zend_long pwbo; ZEND_PARSE_PARAMETERS_START(1,1) Z_PARAM_LONG(pwbo) ZEND_PARSE_PARAMETERS_END(); RETURN_LONG(wbVlcGetVolume((PWBOBJ)pwbo)); }
+ZEND_FUNCTION(wb_vlc_is_playing) { zend_long pwbo; ZEND_PARSE_PARAMETERS_START(1,1) Z_PARAM_LONG(pwbo) ZEND_PARSE_PARAMETERS_END(); RETURN_BOOL(wbVlcIsPlaying((PWBOBJ)pwbo)); }
+
 
 //------------------------------------------------------------------ END OF FILE

--- a/phpwb_export.c
+++ b/phpwb_export.c
@@ -170,6 +170,18 @@ ZEND_FUNCTION(wb_scintilla_calltip_cancel);
 ZEND_FUNCTION(wb_scintilla_set_whitespace_view);
 ZEND_FUNCTION(wb_scintilla_set_eol_view);
 ZEND_FUNCTION(wb_scintilla_show_php_autocomplete);
+ZEND_FUNCTION(wb_vlc_set_media);
+ZEND_FUNCTION(wb_vlc_play);
+ZEND_FUNCTION(wb_vlc_pause);
+ZEND_FUNCTION(wb_vlc_stop);
+ZEND_FUNCTION(wb_vlc_seek);
+ZEND_FUNCTION(wb_vlc_get_time);
+ZEND_FUNCTION(wb_vlc_get_length);
+ZEND_FUNCTION(wb_vlc_set_position);
+ZEND_FUNCTION(wb_vlc_get_position);
+ZEND_FUNCTION(wb_vlc_set_volume);
+ZEND_FUNCTION(wb_vlc_get_volume);
+ZEND_FUNCTION(wb_vlc_is_playing);
 
 // PHPWB_DRAW.C
 ZEND_FUNCTION(wb_get_pixel);
@@ -423,9 +435,21 @@ zend_function_entry winbinder_functions[] =
         ZEND_FE(wb_scintilla_autocomplete_cancel,arginfo_wb_scintilla_autocomplete_cancel)
         ZEND_FE(wb_scintilla_calltip_show,arginfo_wb_scintilla_calltip_show)
         ZEND_FE(wb_scintilla_calltip_cancel,arginfo_wb_scintilla_calltip_cancel)
-        ZEND_FE(wb_scintilla_set_whitespace_view,arginfo_wb_scintilla_set_whitespace_view)
-        ZEND_FE(wb_scintilla_set_eol_view,arginfo_wb_scintilla_set_eol_view)
-        ZEND_FE(wb_scintilla_show_php_autocomplete,arginfo_wb_scintilla_show_php_autocomplete)
+		ZEND_FE(wb_scintilla_set_whitespace_view,arginfo_wb_scintilla_set_whitespace_view)
+		ZEND_FE(wb_scintilla_set_eol_view,arginfo_wb_scintilla_set_eol_view)
+		ZEND_FE(wb_scintilla_show_php_autocomplete,arginfo_wb_scintilla_show_php_autocomplete)
+		ZEND_FE(wb_vlc_set_media,arginfo_wb_vlc_set_media)
+		ZEND_FE(wb_vlc_play,arginfo_wb_vlc_play)
+		ZEND_FE(wb_vlc_pause,arginfo_wb_vlc_pause)
+		ZEND_FE(wb_vlc_stop,arginfo_wb_vlc_stop)
+		ZEND_FE(wb_vlc_seek,arginfo_wb_vlc_seek)
+		ZEND_FE(wb_vlc_get_time,arginfo_wb_vlc_get_time)
+		ZEND_FE(wb_vlc_get_length,arginfo_wb_vlc_get_length)
+		ZEND_FE(wb_vlc_set_position,arginfo_wb_vlc_set_position)
+		ZEND_FE(wb_vlc_get_position,arginfo_wb_vlc_get_position)
+		ZEND_FE(wb_vlc_set_volume,arginfo_wb_vlc_set_volume)
+		ZEND_FE(wb_vlc_get_volume,arginfo_wb_vlc_get_volume)
+		ZEND_FE(wb_vlc_is_playing,arginfo_wb_vlc_is_playing)
 
         // PHPWB_CONTROL_LISTVIEW.C
         ZEND_FE(wb_create_listview_item,arginfo_wb_create_listview_item)
@@ -556,6 +580,7 @@ ZEND_MINIT_FUNCTION(winbinder)
 	WB_ZEND_CONST(LONG, "Frame", Frame)
 	WB_ZEND_CONST(LONG, "Gauge", Gauge)
 	WB_ZEND_CONST(LONG, "HTMLControl", HTMLControl)
+	WB_ZEND_CONST(LONG, "VLCPlayer", VLCPlayer)
 	WB_ZEND_CONST(LONG, "HyperLink", HyperLink)
 	WB_ZEND_CONST(LONG, "ImageButton", ImageButton)
 	WB_ZEND_CONST(LONG, "InvisibleArea", InvisibleArea)

--- a/phpwb_wb_arginfo.h
+++ b/phpwb_wb_arginfo.h
@@ -1090,3 +1090,43 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_task_cancel, 0, 1, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, task_id, IS_LONG, 0)
 ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_vlc_set_media, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, path, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, autoplay, _IS_BOOL, 0, "false")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_vlc_play, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_wb_vlc_pause arginfo_wb_vlc_play
+#define arginfo_wb_vlc_stop arginfo_wb_vlc_play
+#define arginfo_wb_vlc_is_playing arginfo_wb_vlc_play
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_vlc_seek, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, position_ms, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_vlc_set_position, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, position, IS_DOUBLE, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_vlc_get_position, 0, 1, IS_DOUBLE, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_vlc_set_volume, 0, 2, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, volume, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_wb_vlc_get_volume, 0, 1, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, wbObject, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+#define arginfo_wb_vlc_get_time arginfo_wb_vlc_get_volume
+#define arginfo_wb_vlc_get_length arginfo_wb_vlc_get_volume

--- a/wb/wb.h
+++ b/wb/wb.h
@@ -208,9 +208,10 @@ enum
 	ScintillaEdit,
 	Timer,
 	Splitter,
+	VLCPlayer,
 };
 
-#define NUMCLASSES Splitter // Must be the last class
+#define NUMCLASSES VLCPlayer // Must be the last class
 
 // Style flags (parameter style of wb_create_window)
 
@@ -556,6 +557,18 @@ int wbGetSplitterPosition(PWBOBJ pwbo, BOOL bAsRatio);
 BOOL wbSetSplitterPanes(PWBOBJ pwbo, PWBOBJ pwboPane1, PWBOBJ pwboPane2);
 BOOL wbSetSplitterMinSizes(PWBOBJ pwbo, int nMinPane1, int nMinPane2);
 BOOL wbSetChartData(PWBOBJ pwbo, const double *xData, const double *yData, int nPoints, int nChartType, int nShowAverage);
+BOOL wbVlcLoad(PWBOBJ pwbo, LPCTSTR pszSource, BOOL bAutoPlay);
+BOOL wbVlcPlay(PWBOBJ pwbo);
+BOOL wbVlcPause(PWBOBJ pwbo);
+BOOL wbVlcStop(PWBOBJ pwbo);
+BOOL wbVlcSeek(PWBOBJ pwbo, LONG_PTR nPositionMs);
+LONG_PTR wbVlcGetTime(PWBOBJ pwbo);
+LONG_PTR wbVlcGetLength(PWBOBJ pwbo);
+BOOL wbVlcSetPosition(PWBOBJ pwbo, double fPosition);
+double wbVlcGetPosition(PWBOBJ pwbo);
+BOOL wbVlcSetVolume(PWBOBJ pwbo, int nVolume);
+int wbVlcGetVolume(PWBOBJ pwbo);
+BOOL wbVlcIsPlaying(PWBOBJ pwbo);
 BOOL wbPanelSetExpanded(PWBOBJ pwbo, BOOL bExpanded);
 BOOL wbPanelToggle(PWBOBJ pwbo);
 BOOL wbPanelSetHeader(PWBOBJ pwbo, LPCTSTR pszText, HANDLE hIcon, BOOL bOwnIcon);

--- a/wb/wb_control.c
+++ b/wb/wb_control.c
@@ -108,6 +108,87 @@ typedef struct
 	BOOL bOwnIcon;
 } PANELDATA, *PPANELDATA;
 
+#define VLC_MAGIC 0x564C4331 /* VLC1 */
+
+typedef struct
+{
+	DWORD dwMagic;
+	HMODULE hLibVlc;
+	void *pInstance;
+	void *pMedia;
+	void *pPlayer;
+	void *(*fn_libvlc_new)(int, const char *const *);
+	void (*fn_libvlc_release)(void *);
+	void *(*fn_libvlc_media_new_path)(void *, const char *);
+	void (*fn_libvlc_media_release)(void *);
+	void *(*fn_libvlc_media_player_new_from_media)(void *);
+	void (*fn_libvlc_media_player_release)(void *);
+	int (*fn_libvlc_media_player_play)(void *);
+	void (*fn_libvlc_media_player_pause)(void *);
+	void (*fn_libvlc_media_player_stop)(void *);
+	void (*fn_libvlc_media_player_set_hwnd)(void *, void *);
+	void (*fn_libvlc_media_player_set_time)(void *, long long);
+	long long (*fn_libvlc_media_player_get_time)(void *);
+	long long (*fn_libvlc_media_player_get_length)(void *);
+	void (*fn_libvlc_media_player_set_position)(void *, float);
+	float (*fn_libvlc_media_player_get_position)(void *);
+	int (*fn_libvlc_audio_set_volume)(void *, int);
+	int (*fn_libvlc_audio_get_volume)(void *);
+	int (*fn_libvlc_media_player_is_playing)(void *);
+} WBVLC, *PWBVLC;
+
+static BOOL wbVlcResolve(PWBVLC pVlc)
+{
+#define WBVLC_BIND(name) do { pVlc->fn_##name = (void *)GetProcAddress(pVlc->hLibVlc, #name); if (!pVlc->fn_##name) return FALSE; } while (0)
+	WBVLC_BIND(libvlc_new);
+	WBVLC_BIND(libvlc_release);
+	WBVLC_BIND(libvlc_media_new_path);
+	WBVLC_BIND(libvlc_media_release);
+	WBVLC_BIND(libvlc_media_player_new_from_media);
+	WBVLC_BIND(libvlc_media_player_release);
+	WBVLC_BIND(libvlc_media_player_play);
+	WBVLC_BIND(libvlc_media_player_pause);
+	WBVLC_BIND(libvlc_media_player_stop);
+	WBVLC_BIND(libvlc_media_player_set_hwnd);
+	WBVLC_BIND(libvlc_media_player_set_time);
+	WBVLC_BIND(libvlc_media_player_get_time);
+	WBVLC_BIND(libvlc_media_player_get_length);
+	WBVLC_BIND(libvlc_media_player_set_position);
+	WBVLC_BIND(libvlc_media_player_get_position);
+	WBVLC_BIND(libvlc_audio_set_volume);
+	WBVLC_BIND(libvlc_audio_get_volume);
+	WBVLC_BIND(libvlc_media_player_is_playing);
+#undef WBVLC_BIND
+	return TRUE;
+}
+
+static PWBVLC wbVlcGetData(PWBOBJ pwbo)
+{
+	PWBVLC pVlc;
+	if (!pwbo || pwbo->uClass != VLCPlayer)
+		return NULL;
+	pVlc = (PWBVLC)pwbo->lparam;
+	if (!pVlc || pVlc->dwMagic != VLC_MAGIC)
+		return NULL;
+	return pVlc;
+}
+
+static char *wbVlcWideToUtf8(LPCTSTR pszText)
+{
+	int nBytes;
+	char *pszUtf8;
+	if (!pszText)
+		return NULL;
+	nBytes = WideCharToMultiByte(CP_UTF8, 0, pszText, -1, NULL, 0, NULL, NULL);
+	if (nBytes <= 0)
+		return NULL;
+	pszUtf8 = wbMalloc((size_t)nBytes);
+	if (!pszUtf8)
+		return NULL;
+	WideCharToMultiByte(CP_UTF8, 0, pszText, -1, pszUtf8, nBytes, NULL, NULL);
+	return pszUtf8;
+}
+
 static LPTSTR ChartDupText(LPCTSTR pszText)
 {
 	UINT64 nLen;
@@ -1028,6 +1109,12 @@ PWBOBJ wbCreateControl(PWBOBJ pwboParent, UINT64 uWinBinderClass, LPCTSTR pszSou
 		dwStyle = WS_CHILD | nVisible;
 		break;
 
+	case VLCPlayer:
+		pszClass = TEXT("STATIC");
+		dwStyle = WS_CHILD | WS_CLIPCHILDREN | WS_CLIPSIBLINGS | nVisible;
+		dwExStyle |= WS_EX_CLIENTEDGE;
+		break;
+
 	default:
 		wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Unknown control class %d"), uWinBinderClass);
 		return NULL;
@@ -1063,6 +1150,38 @@ PWBOBJ wbCreateControl(PWBOBJ pwboParent, UINT64 uWinBinderClass, LPCTSTR pszSou
 	case HTMLControl:
 		EmbedBrowserObject(pwbo);
 		break;
+
+	case VLCPlayer:
+	{
+		PWBVLC pVlc = wbCalloc(1, sizeof(WBVLC));
+		const char *args[] = {"--no-video-title-show", "--quiet"};
+		if (!pVlc)
+			break;
+		pVlc->dwMagic = VLC_MAGIC;
+		pVlc->hLibVlc = LoadLibrary(TEXT("libvlc.dll"));
+		if (!pVlc->hLibVlc || !wbVlcResolve(pVlc))
+		{
+			if (pVlc->hLibVlc)
+				FreeLibrary(pVlc->hLibVlc);
+			wbFree(pVlc);
+			pwbo->lparam = 0;
+			wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("Could not initialize VLCPlayer (libvlc.dll not found or incompatible)"));
+			break;
+		}
+		pVlc->pInstance = pVlc->fn_libvlc_new(2, args);
+		if (!pVlc->pInstance)
+		{
+			FreeLibrary(pVlc->hLibVlc);
+			wbFree(pVlc);
+			pwbo->lparam = 0;
+			wbError(TEXT(__FUNCTION__), MB_ICONWARNING, TEXT("libvlc_new failed for VLCPlayer"));
+			break;
+		}
+		pwbo->lparam = (LPARAM)pVlc;
+		if (pszCaption && *pszCaption)
+			wbVlcLoad(pwbo, pszCaption, FALSE);
+	}
+	break;
 
 	case RadioButton:
 	case CheckBox:
@@ -1348,6 +1467,46 @@ BOOL wbPanelToggle(PWBOBJ pwbo)
 	return wbPanelSetExpanded(pwbo, !pData->bExpanded);
 }
 
+BOOL wbVlcLoad(PWBOBJ pwbo, LPCTSTR pszSource, BOOL bAutoPlay)
+{
+	PWBVLC pVlc = wbVlcGetData(pwbo);
+	char *pszUtf8;
+	void *pMedia;
+	if (!pVlc || !pszSource || !*pszSource)
+		return FALSE;
+	pszUtf8 = wbVlcWideToUtf8(pszSource);
+	if (!pszUtf8)
+		return FALSE;
+	pMedia = pVlc->fn_libvlc_media_new_path(pVlc->pInstance, pszUtf8);
+	wbFree(pszUtf8);
+	if (!pMedia)
+		return FALSE;
+	if (pVlc->pMedia)
+		pVlc->fn_libvlc_media_release(pVlc->pMedia);
+	if (pVlc->pPlayer)
+		pVlc->fn_libvlc_media_player_release(pVlc->pPlayer);
+	pVlc->pMedia = pMedia;
+	pVlc->pPlayer = pVlc->fn_libvlc_media_player_new_from_media(pMedia);
+	if (!pVlc->pPlayer)
+		return FALSE;
+	pVlc->fn_libvlc_media_player_set_hwnd(pVlc->pPlayer, pwbo->hwnd);
+	if (bAutoPlay)
+		return pVlc->fn_libvlc_media_player_play(pVlc->pPlayer) == 0;
+	return TRUE;
+}
+
+BOOL wbVlcPlay(PWBOBJ pwbo) { PWBVLC pVlc = wbVlcGetData(pwbo); return pVlc && pVlc->pPlayer ? pVlc->fn_libvlc_media_player_play(pVlc->pPlayer) == 0 : FALSE; }
+BOOL wbVlcPause(PWBOBJ pwbo) { PWBVLC pVlc = wbVlcGetData(pwbo); if (!pVlc || !pVlc->pPlayer) return FALSE; pVlc->fn_libvlc_media_player_pause(pVlc->pPlayer); return TRUE; }
+BOOL wbVlcStop(PWBOBJ pwbo) { PWBVLC pVlc = wbVlcGetData(pwbo); if (!pVlc || !pVlc->pPlayer) return FALSE; pVlc->fn_libvlc_media_player_stop(pVlc->pPlayer); return TRUE; }
+BOOL wbVlcSeek(PWBOBJ pwbo, LONG_PTR nPositionMs) { PWBVLC pVlc = wbVlcGetData(pwbo); if (!pVlc || !pVlc->pPlayer) return FALSE; pVlc->fn_libvlc_media_player_set_time(pVlc->pPlayer, (long long)nPositionMs); return TRUE; }
+LONG_PTR wbVlcGetTime(PWBOBJ pwbo) { PWBVLC pVlc = wbVlcGetData(pwbo); return pVlc && pVlc->pPlayer ? (LONG_PTR)pVlc->fn_libvlc_media_player_get_time(pVlc->pPlayer) : -1; }
+LONG_PTR wbVlcGetLength(PWBOBJ pwbo) { PWBVLC pVlc = wbVlcGetData(pwbo); return pVlc && pVlc->pPlayer ? (LONG_PTR)pVlc->fn_libvlc_media_player_get_length(pVlc->pPlayer) : -1; }
+BOOL wbVlcSetPosition(PWBOBJ pwbo, double fPosition) { PWBVLC pVlc = wbVlcGetData(pwbo); if (!pVlc || !pVlc->pPlayer) return FALSE; pVlc->fn_libvlc_media_player_set_position(pVlc->pPlayer, (float)fPosition); return TRUE; }
+double wbVlcGetPosition(PWBOBJ pwbo) { PWBVLC pVlc = wbVlcGetData(pwbo); return pVlc && pVlc->pPlayer ? pVlc->fn_libvlc_media_player_get_position(pVlc->pPlayer) : -1.0; }
+BOOL wbVlcSetVolume(PWBOBJ pwbo, int nVolume) { PWBVLC pVlc = wbVlcGetData(pwbo); return pVlc && pVlc->pPlayer ? pVlc->fn_libvlc_audio_set_volume(pVlc->pPlayer, nVolume) == 0 : FALSE; }
+int wbVlcGetVolume(PWBOBJ pwbo) { PWBVLC pVlc = wbVlcGetData(pwbo); return pVlc && pVlc->pPlayer ? pVlc->fn_libvlc_audio_get_volume(pVlc->pPlayer) : -1; }
+BOOL wbVlcIsPlaying(PWBOBJ pwbo) { PWBVLC pVlc = wbVlcGetData(pwbo); return pVlc && pVlc->pPlayer ? pVlc->fn_libvlc_media_player_is_playing(pVlc->pPlayer) != 0 : FALSE; }
+
 /* Destroy a control created by wbCreateControl(). */
 
 BOOL wbDestroyControl(PWBOBJ pwbo)
@@ -1394,6 +1553,26 @@ BOOL wbDestroyControl(PWBOBJ pwbo)
 	{
 		if (pwbo->lparams[7])
 			wbFree((void *)pwbo->lparams[7]);
+	}
+	else if (pwbo->uClass == VLCPlayer && pwbo->lparam)
+	{
+		PWBVLC pVlc = wbVlcGetData(pwbo);
+		if (pVlc)
+		{
+			if (pVlc->pPlayer)
+			{
+				pVlc->fn_libvlc_media_player_stop(pVlc->pPlayer);
+				pVlc->fn_libvlc_media_player_release(pVlc->pPlayer);
+			}
+			if (pVlc->pMedia)
+				pVlc->fn_libvlc_media_release(pVlc->pMedia);
+			if (pVlc->pInstance)
+				pVlc->fn_libvlc_release(pVlc->pInstance);
+			if (pVlc->hLibVlc)
+				FreeLibrary(pVlc->hLibVlc);
+			pVlc->dwMagic = 0;
+			wbFree(pVlc);
+		}
 	}
 	return DestroyWindow(pwbo->hwnd);
 }
@@ -1746,6 +1925,9 @@ BOOL wbSetText(PWBOBJ pwbo, LPCTSTR pszSourceText, int nItem, BOOL bTooltip)
 			//				return DisplayHTMLPage(pwbo, pszText);
 			//			else
 			return DisplayHTMLString(pwbo, pszText);
+
+		case VLCPlayer:
+			return wbVlcLoad(pwbo, pszText, FALSE);
 
 		case StatusBar:
 			if (SendMessage(pwbo->hwnd, SB_GETPARTS, 0, 0) > 1)

--- a/wb/wb_winsys.c
+++ b/wb/wb_winsys.c
@@ -1063,6 +1063,7 @@ BOOL wbIsValidClass(UINT64 uClass)
 	case Frame:
 	case Gauge:
 	case HTMLControl:
+	case VLCPlayer:
 	case HyperLink:
 	case ImageButton:
 	case InvisibleArea:


### PR DESCRIPTION
### Motivation
- Provide an embedded VLC-based media control for WinBinder so PHP UIs can play media via libvlc.
- Expose a small set of playback APIs to PHP so scripts can load, play, pause, stop, seek and query playback state.
- Ship a full example demonstrating how to use the new control from PHP (`docs/manual/examples/vlc_player_demo.php`).

### Description
- Added a new `VLCPlayer` WinBinder control class and updated `wb.h`/class lists so it is a valid control type and the last class (`NUMCLASSES`).
- Implemented native VLC support in `wb/wb_control.c` via a `WBVLC` struct that dynamically loads `libvlc.dll`, resolves required symbols, creates/releases instances/media/player, assigns the control HWND to the VLC player, and implements `wbVlc*` helper functions (`wbVlcLoad`, `wbVlcPlay`, `wbVlcPause`, `wbVlcStop`, `wbVlcSeek`, `wbVlcGetTime`, `wbVlcGetLength`, `wbVlcSetPosition`, `wbVlcGetPosition`, `wbVlcSetVolume`, `wbVlcGetVolume`, `wbVlcIsPlaying`).
- Cleaned up VLC resources during control destruction to stop playback and free libvlc resources and library handles.
- Added PHP extension bindings in `phpwb_control.c`, exports in `phpwb_export.c`, and arginfo in `phpwb_wb_arginfo.h` for the new functions (`wb_vlc_set_media`, `wb_vlc_play`, `wb_vlc_pause`, `wb_vlc_stop`, `wb_vlc_seek`, `wb_vlc_get_time`, `wb_vlc_get_length`, `wb_vlc_set_position`, `wb_vlc_get_position`, `wb_vlc_set_volume`, `wb_vlc_get_volume`, `wb_vlc_is_playing`).
- Added a demo script `docs/manual/examples/vlc_player_demo.php` that shows a complete UI with open/play/pause/stop, seek and volume controls and status display.

### Testing
- No automated tests were added or executed for this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c50694fdf0832c96251405a7ae8145)